### PR TITLE
Removed need for TEMPLATE CMakelists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # cmake
-CMakeLists.txt
 CMakeCache.txt
 CMakeFiles/
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ addons:
       - g++-4.8
       - gfortran-4.8
       - build-essential
-      - perl
+      - openmpi-bin
+      - libopenmpi-dev
       - cmake
-      - m4
       - git
       - liblapack-dev
-      - liblapack-doc
       - liblapack3gf
       - libblas-dev
       - libblas3gf
@@ -26,11 +25,10 @@ before_install:
 
 install:
   - sh conf/install-deps.sh
-  - cp conf/CMakeLists.txt.travis ./CMakeLists.txt
   - mkdir build; cd build
-  - cmake ../
-  - make
-  - make salvus_test
+  - CC=gcc-4.8 CXX=g++-4.8 FC=gfortran-4.8 cmake ../ -DPETSC_DIR=/home/travis/petsc -DEIGEN_INCLUDE=/home/travis/eigen
+  - make VERBOSE=1 -j
+  - make salvus_test VERBOSE=1 -j
 
   # Install salvus_data as well.
   - cd; cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - sh conf/install-deps.sh
   - mkdir build; cd build
-  - CC=gcc-4.8 CXX=g++-4.8 FC=gfortran-4.8 cmake ../ -DPETSC_DIR=/home/travis/petsc -DEIGEN_INCLUDE=/home/travis/eigen
+  - CC=gcc-4.8 CXX=g++-4.8 FC=gfortran-4.8 cmake ../ -DPETSC_DIR=/home/travis/petsc -DEIGEN_INCLUDE=/home/travis/eigen -DCMAKE_BUILD_TYPE=Debug
   - make VERBOSE=1 -j
   - make salvus_test VERBOSE=1 -j
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(salvus)
+
+###############################################
+# Set all necessary variables here.
+# These variables can be set at the command line:
+# `cmake ../ -DPETSC_DIR=/opt/petsc`
+# or via `ccmake ../`, hitting `c`, editing the
+# respective variable, and then `g`
+SET(PETSC_DIR /opt/petsc CACHE PATH "PETSC install directory")
+SET(EIGEN_INCLUDE /usr/include/eigen3 CACHE PATH "Eigen install directory")
+###############################################
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+      "Choose the type of the builds, options are: Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+find_package(MPI REQUIRED)
+
+link_directories(${PETSC_DIR}/lib)
+
+FILE(GLOB QuadAutoGen src/cxx/Element/HyperCube/Quad/Autogen/*.c)
+FILE(GLOB TriAutoGen src/cxx/Element/Simplex/Triangle/Autogen/*.c)
+
+include_directories(
+  ${MPI_INCLUDE_PATH}
+  ${PETSC_DIR}/include/
+  ${EIGEN_INCLUDE}
+  src/cxx
+  src/cxx/Element
+  src/cxx/Element/HyperCube
+  src/cxx/Element/HyperCube/Quad
+  src/cxx/Element/HyperCube/Quad/Autogen
+  src/cxx/Element/HyperCube/Hex
+  src/cxx/Element/Simplex
+  src/cxx/Element/Simplex/Triangle
+  src/cxx/Element/Simplex/Triangle/Autogen
+  src/cxx/Element/Simplex/Tetrahedron
+  src/cxx/Model)
+
+set(SALVUS_SOURCES
+  src/cxx/Problem/Problem.cpp
+  src/cxx/Problem/NewmarkGeneral.cpp
+  src/cxx/Problem/NewmarkTesting.cpp
+  src/cxx/Mesh/Mesh.cpp
+  src/cxx/Mesh/ElasticNewmark2D.cpp
+  src/cxx/Mesh/ScalarNewmark2D.cpp
+  src/cxx/Element/Element.cpp
+  src/cxx/Element/HyperCube/Quad.cpp
+  src/cxx/Element/HyperCube/Quad/Elastic.cpp
+  src/cxx/Element/HyperCube/Quad/Acoustic.cpp
+  src/cxx/Element/Simplex/Triangle.cpp
+  src/cxx/Element/Simplex/Triangle/AcousticTri.cpp
+  src/cxx/Model/ExodusModel.cpp
+  src/cxx/Utilities/Utilities.cpp
+  src/cxx/Utilities/Options.cpp
+  src/cxx/Source/Source.cpp
+  src/cxx/Utilities/kdtree.c
+  ${QuadAutoGen}
+  ${TriAutoGen}
+  )      
+            
+add_executable(salvus
+  ${SALVUS_SOURCES}
+  src/cxx/Main.cpp  
+  )
+
+add_executable(salvus_test
+  ${SALVUS_SOURCES}
+  src/cxx/Testing/test_main.cpp
+  )
+
+# run `make` (or `make -j5`) to build `salvus` executable
+target_link_libraries(salvus ${MPI_LIBRARIES} petsc exodus netcdf)
+# run `make salvus_test` to build testing executable.
+target_link_libraries(salvus_test ${MPI_LIBRARIES} petsc exodus netcdf)
+set_target_properties(salvus_test PROPERTIES EXCLUDE_FROM_ALL TRUE) # doesn't get built by `make`

--- a/README.md
+++ b/README.md
@@ -1,62 +1,65 @@
 # salvus
 [![Build Status](https://travis-ci.org/SalvusHub/salvus.svg?branch=master)](https://travis-ci.org/SalvusHub/salvus)
 
-Ask not what your spectral element wave propagator can do for you, but what you can do for your spectral element wave propagator.
+Ask not what your spectral element wave propagator can do for you, but
+what you can do for your spectral element wave propagator.
 
 ## Installation
 
-Download PETSc (at least 3.6.x) from http://www.mcs.anl.gov/petsc/download/, unpack it, and install it with all the required libraries. Adjust the `prefix` to where you want it installed.
+Download PETSc (at least 3.6.x) from
+http://www.mcs.anl.gov/petsc/download/, unpack it, and install it with
+all the required libraries. Adjust the `prefix` to where you want it
+installed.
 
 
 ```bash
-$ ./configure --prefix=/opt/petsc --download-exodusii --download-netcdf --download-hdf5 --download-chaco
+./configure --prefix=/opt/petsc --download-exodusii --download-netcdf --download-hdf5 --download-chaco
 ```
 
 At the end of each command it tells you to run some other command. Do that
 until it is done with everything.
 
-You also need to install version 3.x of the `eigen` library and version 3.x of `cmake`:
+You also need to install version 3.x of the `eigen` library, the build
+tool `cmake`, and at least g++ 4.8 (for C++11 features):
 
 ```bash
-$ brew install eigen cmake          # OSX
+brew install eigen cmake gcc48         # OSX
 ```
-
-and on Ubuntu 14.04 (which doesn't include cmake 3.x natively)
+and on Ubuntu 12.04
 
 ``` bash
-$ sudo apt-get install libeigen3-dev 
-$ sudo add-apt-repository ppa:george-edison55/cmake-3.x
-$ sudo apt-get update
-$ sudo apt-get install cmake
+sudo apt-get install libeigen3-dev cmake gcc-4.8 g++-4.8
 ```
 
-Then copy the `CMakeLists.txt.TEMPLATE` file
-
-```bash
-cp CMakeLists.txt.TEMPLATE CMakeLists.txt
-```
-
-and edit the following block in `CMakeLists.txt`. `PETSC_DIR` is the `prefix` chosen above.
-
-```cmake
-###############################################
-# Set all necessary variables here.
-# Please only try to edit in this block. If something is
-# missing add it.
-SET(CMAKE_C_COMPILER /usr/bin/mpicc)
-SET(CMAKE_CXX_COMPILER /usr/bin/mpicxx)
-SET(PETSC_DIR /opt/petsc)
-SET(EIGEN_INCLUDE /usr/include/eigen3)
-###############################################
-```
-
-It is a good idea to do an "out of source build" to keep the `salvus` directory clean of build artifacts.
+It is a good idea to do an "out of source build" to keep the `salvus`
+directory clean of build artifacts.
 
 ``` bash
 mkdir build
 cd build
-cmake ../
 ```
+
+Several library variables will need setting in order to successfully
+compile. From you build directory, you can directly set the
+`PETSC_DIR`, and `EIGEN_INCLUDE` directories via `ccmake ../`. Hit the
+`c` key to "configure", make your changes, and hit `g` to generate the
+Makefiles. Alternatively, you can achieve this via `cmake` on the
+command line via
+
+``` bash
+CC=gcc-4.8 CXX=g++4.8 cmake ../ -DPETSC_DIR=/opt/petsc -DEIGEN_INCLUDE=/usr/include/eigen3
+```
+
+Note the usage of `CC=gcc-4.8 CXX=g++4.8`, which is used to change the
+default compiler used. This only works the **first** time `cmake` is
+run (it gets cached). `cmake` manages the linking to mpi includes and
+libraries itself, so no need to use a wrapper such as `mpicc` or
+`mpic++`.
+
+By default, Salvus is compiled with optimizations (i.e., a release
+build). To compile for debugging (which adds `-g` and removes `-O3`),
+add `-DCMAKE_BUILD_TYPE=Debug` (instead of `Release`) to the **first**
+run of `cmake ../`.
 
 Finally compile `salvus` with
 

--- a/conf/install-deps.sh
+++ b/conf/install-deps.sh
@@ -2,16 +2,14 @@
 
 # PETSc
 cd
-git clone -b maint https://bitbucket.org/petsc/petsc petsc;
-cd petsc
+git clone -b maint https://bitbucket.org/petsc/petsc petsc-src;
+cd petsc-src
 
 # Configure and install.
 ./configure --download-exodusii --download-netcdf --download-hdf5 --download-chaco \
---with-cc=/usr/bin/gcc-4.8 --with-fc=/usr/bin/gfortran-4.8 --with-cxx=/usr/bin/g++-4.8 \
---download-openmpi=yes
-make PETSC_DIR=/home/travis/petsc PETSC_ARCH=arch-linux2-c-debug all
-make PETSC_DIR=/home/travis/petsc PETSC_ARCH=arch-linux2-c-debug test
-make PETSC_DIR=/home/travis/petsc PETSC_ARCH=arch-linux2-c-debug streams NPMAX=2
+            --prefix=/home/travis/petsc
+make 
+make install
 
 # Eigen
 cd


### PR DESCRIPTION
* Template no longer -- follow instructions on readme
* Travis Cmakelists uses standard CMakelists
* Updated readme for Debug/Release
* Much faster Travis time --- uses system MPI instead of recompiling
  using PETSc