### PR TITLE
Multi field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,14 +62,14 @@ set(SALVUS_SOURCES
   src/cxx/Utilities/Options.cpp
   src/cxx/Source/Source.cpp
   src/cxx/Utilities/kdtree.c
+  src/cxx/Utilities/PETScExtensions.c
   ${QuadAutoGen}
   ${TriAutoGen}
   )      
             
 add_executable(salvus
   ${SALVUS_SOURCES}
-  src/cxx/Main.cpp  
-  )
+  src/cxx/Main.cpp)
 
 add_executable(salvus_test
   ${SALVUS_SOURCES}

--- a/src/cxx/Element/Element.h
+++ b/src/cxx/Element/Element.h
@@ -193,6 +193,7 @@ class Element {
   inline int NumDofEdg() const { return mNumDofEdg; }
   inline int NumDofFac() const { return mNumDofFac; }
   inline int NumDofVtx() const { return mNumDofVtx; }
+  inline int NumDofVol() const { return mNumDofVol; }
   inline int NumIntPnt() const { return mNumIntPnt; }
   inline bool BndElm() const { return mBndElm; }
   inline VectorXi ClsMap() { return mClsMap; }

--- a/src/cxx/Element/HyperCube/Quad.cpp
+++ b/src/cxx/Element/HyperCube/Quad.cpp
@@ -28,6 +28,7 @@ Quad::Quad(Options options) {
   mNumDofVtx = 1;
   mNumDofEdg = mPlyOrd - 1;
   mNumDofFac = (mPlyOrd - 1) * (mPlyOrd - 1);
+  mNumDofVol = 0;
 
   // Integration points.
   mClsMap = Quad::ClosureMapping(options.PolynomialOrder(), mNumDim);

--- a/src/cxx/Element/Simplex/Triangle.cpp
+++ b/src/cxx/Element/Simplex/Triangle.cpp
@@ -77,6 +77,7 @@ Triangle::Triangle(Options options) {
         mNumIntPnt = 12;
         mNumDofEdg = 2;
         mNumDofFac = 3;
+        mNumDofVol = 0;
     }
     else {
         std::cerr << "ERROR: Order NOT implemented!\n";

--- a/src/cxx/Mesh/Mesh.cpp
+++ b/src/cxx/Mesh/Mesh.cpp
@@ -2,7 +2,6 @@
 // Created by Michael Afanasiev on 2016-01-27.
 //
 
-#include <vector>
 #include "Mesh.h"
 #include "ScalarNewmark2D.h"
 #include "ElasticNewmark2D.h"
@@ -220,7 +219,7 @@ PetscErrorCode Mesh::setupGlobalDof(int num_dof_vtx, int num_dof_edg,
                               depth >  2 ? &p_max[1]       : NULL,
                               &p_max[0]);CHKERRQ(ier);
 
-  // dep = 0 -> edg; dep = 1 -> vtx; dep = 2 -> fac.
+  // dep = 0 -> fac; dep = 1 -> edg; dep = 2 -> vtx.
   assert(depth == 2); // Can only handle 2-D elements for now.
   for (int dep = 0; dep <= depth; dep++) {
     int num_dof = 0;
@@ -348,6 +347,8 @@ void Mesh::addFieldFromFace(const std::string &name, const int face_number, cons
 
 Eigen::VectorXd Mesh::getFieldOnElement(const std::string &name, const int &element_number,
                                         const Eigen::VectorXi &closure) {
+
+//  DMPlexGetClosureIndices()
 
   PetscScalar *val = NULL;
   Eigen::VectorXd field(closure.size());

--- a/src/cxx/Mesh/Mesh.cpp
+++ b/src/cxx/Mesh/Mesh.cpp
@@ -11,9 +11,9 @@
 
 void exodusError(const int retval, std::string func_name) {
 
-    if (retval) {
-        throw std::runtime_error("Error in exodus function: " + func_name);
-    }
+  if (retval) {
+    throw std::runtime_error("Error in exodus function: " + func_name);
+  }
 
 }
 
@@ -23,362 +23,396 @@ extern "C" {
 
 Mesh *Mesh::factory(Options options) {
 
-    std::string mesh_type(options.MeshType());
-    try {
-        if (mesh_type == "newmark") {
-            auto sc_nm_mesh = new ScalarNewmark2D();
-            if(options.TestIC()) {
-                // add nodal location to global field vectors for testing
-                sc_nm_mesh->AddToGlobalFields("x");
-                sc_nm_mesh->AddToGlobalFields("z");
-                sc_nm_mesh->AddToGlobalFields("u_exact");
-            }
-            return sc_nm_mesh;            
-        } else if (mesh_type == "newmark_2d_elastic"){
-            return new ElasticNewmark2D();
-        } else {
-            throw std::runtime_error("Runtime Error: Mesh type " + mesh_type + " not supported");
-        }
-    } catch (std::exception &e) {
-        utilities::print_from_root_mpi(e.what());
-        MPI::COMM_WORLD.Abort(-1);
-        return nullptr;
-    };
+  std::string mesh_type(options.MeshType());
+  try {
+    if (mesh_type == "newmark") {
+      auto sc_nm_mesh = new ScalarNewmark2D();
+      if (options.TestIC()) {
+        // add nodal location to global field vectors for testing
+        sc_nm_mesh->AddToGlobalFields("x");
+        sc_nm_mesh->AddToGlobalFields("z");
+        sc_nm_mesh->AddToGlobalFields("u_exact");
+      }
+      return sc_nm_mesh;
+    } else if (mesh_type == "newmark_2d_elastic") {
+      return new ElasticNewmark2D();
+    } else {
+      throw std::runtime_error("Runtime Error: Mesh type " + mesh_type + " not supported");
+    }
+  } catch (std::exception &e) {
+    utilities::print_from_root_mpi(e.what());
+    MPI::COMM_WORLD.Abort(-1);
+    return nullptr;
+  };
 
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "readBoundaryNames"
 int Mesh::readBoundaryNames(Options options) {
-    
-    PetscFunctionBegin;
-    std::vector<std::string> boundary_names;
-    if (MPI::COMM_WORLD.Get_rank() == 0) {
-     
-        int num_boundaries = -1;
-        float exodus_version;
-        int io_ws = 0;
-        int comp_ws = 8;
-        try {
-            int exoid = ex_open(options.ExodusMeshFile().c_str() , EX_READ, &comp_ws, &io_ws, &exodus_version);
-            if (exoid < 0) { throw std::runtime_error("Error opening exodus model file."); }
-            float fdum = 0.0;
-            char* cdum = 0;
-            exodusError(ex_inquire(exoid,EX_INQ_SIDE_SETS,&num_boundaries,&fdum,cdum),"ex_inq");
-            for(int b=1;b<=num_boundaries;b++) {
-                char name[1024];
-                int ret=-1;
-                // retrieve name from id={1,2,3..}
-                // note that blank spaces given in Trelis get an underscore.
-                exodusError(ex_get_name(exoid,EX_SIDE_SET,b,name),"ex_get_name");
-                std::string namestr(name);
-                boundary_names.push_back(name);
-            }
-        } catch (std::exception &e) {
-            std::cerr << "ERROR(rank=" << MPI::COMM_WORLD.Get_rank() << ")!: " << e.what();
-            MPI_Abort(PETSC_COMM_WORLD, -1);
-        }
-    } // rank==0        
-        
-    std::cout << "boundary_names =" << boundary_names[0] << "\n";
-    boundary_names = utilities::broadcastStringVecFromFroot(boundary_names);
-    // Build mapping boundary name -> label value (id). `id` starts counting at 1.
-    for(int i=0;i<boundary_names.size();i++) {
-        mBoundaryIds[i+1] = boundary_names[i];
-    }        
-    MPI::COMM_WORLD.Barrier();
-    PetscFunctionReturn(0);
+
+  PetscFunctionBegin;
+  std::vector<std::string> boundary_names;
+  if (MPI::COMM_WORLD.Get_rank() == 0) {
+
+    int num_boundaries = -1;
+    float exodus_version;
+    int io_ws = 0;
+    int comp_ws = 8;
+    try {
+      int exoid = ex_open(options.ExodusMeshFile().c_str(), EX_READ, &comp_ws, &io_ws, &exodus_version);
+      if (exoid < 0) { throw std::runtime_error("Error opening exodus model file."); }
+      float fdum = 0.0;
+      char *cdum = 0;
+      exodusError(ex_inquire(exoid, EX_INQ_SIDE_SETS, &num_boundaries, &fdum, cdum), "ex_inq");
+      for (int b = 1; b <= num_boundaries; b++) {
+        char name[1024];
+        int ret = -1;
+        // retrieve name from id={1,2,3..}
+        // note that blank spaces given in Trelis get an underscore.
+        exodusError(ex_get_name(exoid, EX_SIDE_SET, b, name), "ex_get_name");
+        std::string namestr(name);
+        boundary_names.push_back(name);
+      }
+    } catch (std::exception &e) {
+      std::cerr << "ERROR(rank=" << MPI::COMM_WORLD.Get_rank() << ")!: " << e.what();
+      MPI_Abort(PETSC_COMM_WORLD, -1);
+    }
+  } // rank==0
+
+  std::cout << "boundary_names =" << boundary_names[0] << "\n";
+  boundary_names = utilities::broadcastStringVecFromFroot(boundary_names);
+  // Build mapping boundary name -> label value (id). `id` starts counting at 1.
+  for (int i = 0; i < boundary_names.size(); i++) {
+    mBoundaryIds[i + 1] = boundary_names[i];
+  }
+  MPI::COMM_WORLD.Barrier();
+  PetscFunctionReturn(0);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "setupBoundaries"
 int Mesh::setupBoundaries(Options options) {
-    PetscFunctionBegin;
-    
-    int ierr = 0;
-    
-    readBoundaryNames(options);
+  PetscFunctionBegin;
 
-    // PETSc gives all side sets the label name "Face Sets" Each face
-    // is then given value, which is the order found in the exodus
-    // file; Ex: two boundaries "absorbing_boundaries", "free_surface"
-    // faces on absorbing boundary get label value "1", and faces on
-    // free surface get value "2".
-    DMLabel label;
-    ierr = DMPlexGetLabel(mDistributedMesh,"Face Sets",&label);CHKERRQ(ierr);
+  int ierr = 0;
 
-    // if no side sets are present, proceed with no boundaries (naturally a free surface)
-    if(label == NULL) { return 0; }
-    ierr = DMLabelGetNumValues(label, &mNumberSideSets);CHKERRQ(ierr);
-    if(mNumberSideSets == 0) {return 0;}
-    
-    IS idIS;
-    const PetscInt* ids;
-    ierr = DMLabelGetValueIS(label, &idIS);CHKERRQ(ierr);
-    ierr = ISGetIndices(idIS, &ids);CHKERRQ(ierr);
-    
-    for (int i = 0; i < mNumberSideSets; i++) {
+  readBoundaryNames(options);
 
-        IS              pointIS;
-        const PetscInt *faces;
-        PetscInt        numFaces, p;
+  // PETSc gives all side sets the label name "Face Sets" Each face
+  // is then given value, which is the order found in the exodus
+  // file; Ex: two boundaries "absorbing_boundaries", "free_surface"
+  // faces on absorbing boundary get label value "1", and faces on
+  // free surface get value "2".
+  DMLabel label;
+  ierr = DMPlexGetLabel(mDistributedMesh, "Face Sets", &label);
+  CHKERRQ(ierr);
 
-        ierr = DMLabelGetStratumSize(label, ids[i], &numFaces);CHKERRQ(ierr);
-        ierr = DMLabelGetStratumIS(label, ids[i], &pointIS);CHKERRQ(ierr);
-        ierr = ISGetIndices(pointIS, &faces);CHKERRQ(ierr);
-        auto boundary_name = mBoundaryIds[ids[i]];
-        std::cout << "getting boundary_name=" << boundary_name << "\n";
-        for (int p = 0; p < numFaces; p++) {
+  // if no side sets are present, proceed with no boundaries (naturally a free surface)
+  if (label == NULL) { return 0; }
+  ierr = DMLabelGetNumValues(label, &mNumberSideSets);
+  CHKERRQ(ierr);
+  if (mNumberSideSets == 0) { return 0; }
 
-            PetscInt support_size;
-            const PetscInt* support;
-            int face = faces[p];
-            DMPlexGetSupportSize(mDistributedMesh, face, &support_size);
-            DMPlexGetSupport(mDistributedMesh, face, &support);
-            for(int elem = 0; elem < support_size; elem++) {                
-                mBoundaryElementFaces[boundary_name][support[elem]].push_back(face);
-            }
-        }
-        ISRestoreIndices(pointIS, &faces);
-        ISDestroy(&pointIS);
+  IS idIS;
+  const PetscInt *ids;
+  ierr = DMLabelGetValueIS(label, &idIS);
+  CHKERRQ(ierr);
+  ierr = ISGetIndices(idIS, &ids);
+  CHKERRQ(ierr);
+
+  for (int i = 0; i < mNumberSideSets; i++) {
+
+    IS pointIS;
+    const PetscInt *faces;
+    PetscInt numFaces, p;
+
+    ierr = DMLabelGetStratumSize(label, ids[i], &numFaces);
+    CHKERRQ(ierr);
+    ierr = DMLabelGetStratumIS(label, ids[i], &pointIS);
+    CHKERRQ(ierr);
+    ierr = ISGetIndices(pointIS, &faces);
+    CHKERRQ(ierr);
+    auto boundary_name = mBoundaryIds[ids[i]];
+    std::cout << "getting boundary_name=" << boundary_name << "\n";
+    for (int p = 0; p < numFaces; p++) {
+
+      PetscInt support_size;
+      const PetscInt *support;
+      int face = faces[p];
+      DMPlexGetSupportSize(mDistributedMesh, face, &support_size);
+      DMPlexGetSupport(mDistributedMesh, face, &support);
+      for (int elem = 0; elem < support_size; elem++) {
+        mBoundaryElementFaces[boundary_name][support[elem]].push_back(face);
+      }
     }
-    ierr = ISRestoreIndices(idIS, &ids);CHKERRQ(ierr);
-    ISDestroy(&idIS);
+    ISRestoreIndices(pointIS, &faces);
+    ISDestroy(&pointIS);
+  }
+  ierr = ISRestoreIndices(idIS, &ids);
+  CHKERRQ(ierr);
+  ISDestroy(&idIS);
 
-    PetscFunctionReturn(0);
+  PetscFunctionReturn(0);
 }
 
 void Mesh::read(Options options) {
 
-    // Class variables.
-    mDistributedMesh = NULL;
-    mExodusFileName = options.ExodusMeshFile();
+  // Class variables.
+  mDistributedMesh = NULL;
+  mExodusFileName = options.ExodusMeshFile();
 
-    // Function variables.
-    DM dm = NULL;
-    PetscBool interpolate_edges = PETSC_TRUE;
+  // Function variables.
+  DM dm = NULL;
+  PetscBool interpolate_edges = PETSC_TRUE;
 
-    // Read exodus file.
-    DMPlexCreateExodusFromFile(PETSC_COMM_WORLD, mExodusFileName.c_str(), interpolate_edges, &dm);
+  // Read exodus file.
+  DMPlexCreateExodusFromFile(PETSC_COMM_WORLD, mExodusFileName.c_str(), interpolate_edges, &dm);
 
-    // May be a race condition on distribute.
-    MPI::COMM_WORLD.Barrier();
-    DMPlexDistribute(dm, 0, NULL, &mDistributedMesh);
+  // May be a race condition on distribute.
+  MPI::COMM_WORLD.Barrier();
+  DMPlexDistribute(dm, 0, NULL, &mDistributedMesh);
 
-    // We don't need the serial mesh anymore.
-    if (mDistributedMesh) { DMDestroy(&dm); }
+  // We don't need the serial mesh anymore.
+  if (mDistributedMesh) { DMDestroy(&dm); }
     // mDistributedMesh == NULL when only 1 proc is used.
-    else { mDistributedMesh = dm; }
+  else { mDistributedMesh = dm; }
 
-    DMGetDimension(mDistributedMesh, &mNumberDimensions);
-    DMPlexGetDepthStratum(mDistributedMesh, mNumberDimensions, NULL, &mNumberElementsLocal);
+  DMGetDimension(mDistributedMesh, &mNumberDimensions);
+  DMPlexGetDepthStratum(mDistributedMesh, mNumberDimensions, NULL, &mNumberElementsLocal);
 }
+
+
+PetscErrorCode Mesh::setupGlobalDofNew() {
+
+  PetscErrorCode ier;
+  PetscSection section;
+  PetscInt num_fields, num_comp[1];
+
+  // One field and one components for field as we handle our own discretization.
+  num_fields = 1;
+  num_comp[0] = 1;
+
+  ier = PetscSectionCreate(PetscObjectComm((PetscObject)mDistributedMesh), &section);CHKERRQ(ier);
+  ier = PetscSectionSetNumFields(section, num_fields);CHKERRQ(ier);
+  for (int f = 0; f < num_fields; f++) {
+    ier = PetscSectionSetFieldComponents(section, f, num_comp[f]);CHKERRQ(ier);
+  }
+  PetscInt p_start, p_end;
+  ier = DMPlexGetChart(mDistributedMesh, &p_start, &p_end);CHKERRQ(ier);
+  std::cout << "start,end" << p_start << ' ' << p_end << std::endl;
+  exit(0);
+
+
+}
+
 
 void Mesh::setupGlobalDof(int number_dof_vertex, int number_dof_edge, int number_dof_face,
                           int number_dof_volume, int number_dimensions) {
 
-    // Ensure that the mesh and the elements are the same dimension.
-    assert(number_dimensions == mNumberDimensions);
+  // Ensure that the mesh and the elements are the same dimension.
+  assert(number_dimensions == mNumberDimensions);
 
-    // Only define 1 field here because we're taking care of multiple fields manually.
-    int number_fields = 1;
-    int number_components = 1;
-    int number_dof_per_element[mNumberDimensions + 1];
+  // Only define 1 field here because we're taking care of multiple fields manually.
+  int number_fields = 1;
+  int number_components = 1;
+  int number_dof_per_element[mNumberDimensions + 1];
 
-    // Num of dof on vertex, edge, face, volume.
-    number_dof_per_element[0] = number_dof_vertex;
-    number_dof_per_element[1] = number_dof_edge;
-    number_dof_per_element[2] = number_dof_face;
-    if (mNumberDimensions == 3) { number_dof_per_element[3] = number_dof_volume; }
+  // Num of dof on vertex, edge, face, volume.
+  number_dof_per_element[0] = number_dof_vertex;
+  number_dof_per_element[1] = number_dof_edge;
+  number_dof_per_element[2] = number_dof_face;
+  if (mNumberDimensions == 3) { number_dof_per_element[3] = number_dof_volume; }
 
-    // Setup the global and local (distributed) degrees of freedom.
-    DMPlexCreateSection(mDistributedMesh, mNumberDimensions, number_fields, &number_components,
-                        number_dof_per_element, 0, NULL, NULL, NULL, NULL, &mMeshSection);
-    DMSetDefaultSection(mDistributedMesh, mMeshSection);
+  // Setup the global and local (distributed) degrees of freedom.
+  DMPlexCreateSection(mDistributedMesh, mNumberDimensions, number_fields, &number_components,
+                      number_dof_per_element, 0, NULL, NULL, NULL, NULL, &mMeshSection);
+  DMSetDefaultSection(mDistributedMesh, mMeshSection);
 
-    // improves performance of closure calls (for a 1.5x application perf. boost)
-    DMPlexCreateClosureIndex(mDistributedMesh, mMeshSection);
+  // improves performance of closure calls (for a 1.5x application perf. boost)
+  DMPlexCreateClosureIndex(mDistributedMesh, mMeshSection);
 }
 
 void Mesh::registerFieldVectors(const std::string &name) {
 
-    Vec field_vector_local;
-    Vec field_vector_global;
-    DMCreateLocalVector(mDistributedMesh, &field_vector_local);
-    DMCreateGlobalVector(mDistributedMesh, &field_vector_global);
+  Vec field_vector_local;
+  Vec field_vector_global;
+  DMCreateLocalVector(mDistributedMesh, &field_vector_local);
+  DMCreateGlobalVector(mDistributedMesh, &field_vector_global);
 
-    double zero = 0.0;
-    VecSet(field_vector_local, zero);
-    VecSet(field_vector_global, zero);
-    PetscObjectSetName((PetscObject) field_vector_global, name.c_str());
+  double zero = 0.0;
+  VecSet(field_vector_local, zero);
+  VecSet(field_vector_global, zero);
+  PetscObjectSetName((PetscObject) field_vector_global, name.c_str());
 
-    vec_struct registrar;
-    registrar.name = name;
-    registrar.loc = field_vector_local;
-    registrar.glb = field_vector_global;
-    mFields[name] = registrar;
+  vec_struct registrar;
+  registrar.name = name;
+  registrar.loc = field_vector_local;
+  registrar.glb = field_vector_global;
+  mFields[name] = registrar;
 
 }
 
 void Mesh::checkOutField(const std::string &name) {
 
-    assert(mFields.find(name) != mFields.end());
+  assert(mFields.find(name) != mFields.end());
 
-    // Begin the MPI broadcast global -> local.
-    DMGlobalToLocalBegin(mDistributedMesh, mFields[name].glb, INSERT_VALUES,
-                         mFields[name].loc);
-
-    // End the MPI broadcast global -> local.
-    DMGlobalToLocalEnd(mDistributedMesh, mFields[name].glb, INSERT_VALUES,
+  // Begin the MPI broadcast global -> local.
+  DMGlobalToLocalBegin(mDistributedMesh, mFields[name].glb, INSERT_VALUES,
                        mFields[name].loc);
+
+  // End the MPI broadcast global -> local.
+  DMGlobalToLocalEnd(mDistributedMesh, mFields[name].glb, INSERT_VALUES,
+                     mFields[name].loc);
 
 }
 
 Eigen::VectorXd Mesh::getFieldOnFace(const std::string &name, const int &face_number) {
 
-    PetscScalar *val = NULL;
-    PetscInt num_nodes_face = -1;
-    DMPlexVecGetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        face_number, &num_nodes_face, &val);    
-    Eigen::VectorXd field(num_nodes_face);
-    for (auto j = 0; j < num_nodes_face; j++) { field(j) = val[j]; }
-    DMPlexVecRestoreClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                            face_number, NULL, &val);
-    return field;
+  PetscScalar *val = NULL;
+  PetscInt num_nodes_face = -1;
+  DMPlexVecGetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      face_number, &num_nodes_face, &val);
+  Eigen::VectorXd field(num_nodes_face);
+  for (auto j = 0; j < num_nodes_face; j++) { field(j) = val[j]; }
+  DMPlexVecRestoreClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                          face_number, NULL, &val);
+  return field;
 }
 
 void Mesh::setFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field) {
 
-    Eigen::VectorXd val(field.size());
-    // map "our" nodal ordering back onto PETSC ordering
-    for (auto j = 0; j < field.size(); j++) { val(j) = field(j); }
-    DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        face_number, val.data(), INSERT_VALUES);
+  Eigen::VectorXd val(field.size());
+  // map "our" nodal ordering back onto PETSC ordering
+  for (auto j = 0; j < field.size(); j++) { val(j) = field(j); }
+  DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      face_number, val.data(), INSERT_VALUES);
 }
 
 void Mesh::addFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field) {
 
-    Eigen::VectorXd val(field.size());
-    // map "our" nodal ordering back onto PETSC ordering
-    for (auto j = 0; j < field.size(); j++) { val(j) = field(j); }
-    DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        face_number, val.data(), ADD_VALUES);
+  Eigen::VectorXd val(field.size());
+  // map "our" nodal ordering back onto PETSC ordering
+  for (auto j = 0; j < field.size(); j++) { val(j) = field(j); }
+  DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      face_number, val.data(), ADD_VALUES);
 }
 
 Eigen::VectorXd Mesh::getFieldOnElement(const std::string &name, const int &element_number,
                                         const Eigen::VectorXi &closure) {
 
-    PetscScalar *val = NULL;
-    Eigen::VectorXd field(closure.size());
-    DMPlexVecGetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        element_number, NULL, &val);
-    for (auto j = 0; j < closure.size(); j++) { field(closure(j)) = val[j]; }
-    DMPlexVecRestoreClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                            element_number, NULL, &val);
-    return field;
+  PetscScalar *val = NULL;
+  Eigen::VectorXd field(closure.size());
+  DMPlexVecGetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      element_number, NULL, &val);
+  for (auto j = 0; j < closure.size(); j++) { field(closure(j)) = val[j]; }
+  DMPlexVecRestoreClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                          element_number, NULL, &val);
+  return field;
 
 }
 
 void Mesh::setFieldFromElement(const std::string &name, const int element_number,
                                const Eigen::VectorXi &closure, const Eigen::VectorXd &field) {
 
-    Eigen::VectorXd val(closure.size());
-    // map "our" nodal ordering back onto PETSC ordering
-    for (auto j = 0; j < closure.size(); j++) { val(j) = field(closure(j)); }
-    DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        element_number, val.data(), INSERT_VALUES);
+  Eigen::VectorXd val(closure.size());
+  // map "our" nodal ordering back onto PETSC ordering
+  for (auto j = 0; j < closure.size(); j++) { val(j) = field(closure(j)); }
+  DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      element_number, val.data(), INSERT_VALUES);
 }
 
 void Mesh::addFieldFromElement(const std::string &name, const int element_number,
                                const Eigen::VectorXi &closure, const Eigen::VectorXd &field) {
 
-    Eigen::VectorXd val(closure.size());
-    // map "our" nodal ordering back onto PETSC ordering
-    for (auto j = 0; j < closure.size(); j++) { val(j) = field(closure(j)); }
-    DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
-                        element_number, val.data(), ADD_VALUES);
+  Eigen::VectorXd val(closure.size());
+  // map "our" nodal ordering back onto PETSC ordering
+  for (auto j = 0; j < closure.size(); j++) { val(j) = field(closure(j)); }
+  DMPlexVecSetClosure(mDistributedMesh, mMeshSection, mFields[name].loc,
+                      element_number, val.data(), ADD_VALUES);
 }
 
 void Mesh::assembleLocalFieldToGlobal(const std::string &name) {
 
-    assembleLocalFieldToGlobalBegin(name);
-    assembleLocalFieldToGlobalEnd(name);   
+  assembleLocalFieldToGlobalBegin(name);
+  assembleLocalFieldToGlobalEnd(name);
 }
 
 void Mesh::assembleLocalFieldToGlobalBegin(const std::string &name) {
 
-    // Make sure the field exists in our dictionary.
-    assert(mFields.find(name) != mFields.end());
+  // Make sure the field exists in our dictionary.
+  assert(mFields.find(name) != mFields.end());
 
-    // Begin MPI broadcast local -> global.
-    DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
+  // Begin MPI broadcast local -> global.
+  DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
 }
 
 void Mesh::assembleLocalFieldToGlobalEnd(const std::string &name) {
 
-    // Make sure the field exists in our dictionary.
-    assert(mFields.find(name) != mFields.end());
+  // Make sure the field exists in our dictionary.
+  assert(mFields.find(name) != mFields.end());
 
-    // Begin MPI broadcast local -> global.
-    DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
+  // Begin MPI broadcast local -> global.
+  DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
 }
 
 void Mesh::setLocalFieldToGlobal(const std::string &name) {
-    
-    // Make sure the field exists in our dictionary.
-    assert(mFields.find(name) != mFields.end());
 
-    // Do "communication". `INSERT_VALUE` will result in no communication
-    DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, INSERT_VALUES, mFields[name].glb);
-    DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, INSERT_VALUES, mFields[name].glb);
+  // Make sure the field exists in our dictionary.
+  assert(mFields.find(name) != mFields.end());
+
+  // Do "communication". `INSERT_VALUE` will result in no communication
+  DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, INSERT_VALUES, mFields[name].glb);
+  DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, INSERT_VALUES, mFields[name].glb);
 
 }
 
 void Mesh::checkInFieldBegin(const std::string &name) {
 
-    // Make sure the field exists in our dictionary.
-    assert(mFields.find(name) != mFields.end());
+  // Make sure the field exists in our dictionary.
+  assert(mFields.find(name) != mFields.end());
 
-    // Begin MPI broadcast local -> global.
-    DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
+  // Begin MPI broadcast local -> global.
+  DMLocalToGlobalBegin(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
 }
 
 
 void Mesh::checkInFieldEnd(const std::string &name) {
 
-    // Make sure the field exists in our dictionary.
-    assert(mFields.find(name) != mFields.end());
+  // Make sure the field exists in our dictionary.
+  assert(mFields.find(name) != mFields.end());
 
-    // Begin MPI broadcast local -> global.
-    DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
+  // Begin MPI broadcast local -> global.
+  DMLocalToGlobalEnd(mDistributedMesh, mFields[name].loc, ADD_VALUES, mFields[name].glb);
 
 }
 
 void Mesh::zeroFields(const std::string &name) {
-    double zero = 0.0;
-    VecSet(mFields[name].loc, zero);
-    VecSet(mFields[name].glb, zero);
+  double zero = 0.0;
+  VecSet(mFields[name].loc, zero);
+  VecSet(mFields[name].glb, zero);
 }
 
 void Mesh::setUpMovie(const std::string &movie_filename) {
-    mViewer = nullptr;
-    PetscViewerHDF5Open(PETSC_COMM_WORLD, movie_filename.c_str(), FILE_MODE_WRITE, &mViewer);
-    PetscViewerHDF5PushGroup(mViewer, "/");
-    DMView(mDistributedMesh, mViewer);
+  mViewer = nullptr;
+  PetscViewerHDF5Open(PETSC_COMM_WORLD, movie_filename.c_str(), FILE_MODE_WRITE, &mViewer);
+  PetscViewerHDF5PushGroup(mViewer, "/");
+  DMView(mDistributedMesh, mViewer);
 }
 
-void Mesh::saveFrame(std::string name,PetscInt timestep) {
-    
-    DMSetOutputSequenceNumber(mDistributedMesh, timestep, timestep);
-    VecView(mFields[name].glb, mViewer);
+void Mesh::saveFrame(std::string name, PetscInt timestep) {
+
+  DMSetOutputSequenceNumber(mDistributedMesh, timestep, timestep);
+  VecView(mFields[name].glb, mViewer);
 }
 
 void Mesh::finalizeMovie() {
 
-    PetscViewerHDF5PopGroup(mViewer);
-    PetscViewerDestroy(&mViewer);
+  PetscViewerHDF5PopGroup(mViewer);
+  PetscViewerDestroy(&mViewer);
 
 }
+
 
 // int Mesh::BoundaryElementFaces(int elm, int ss_num) {
 
@@ -390,6 +424,6 @@ void Mesh::finalizeMovie() {
 //     // } else {
 //     //     return mBoundaryElementFaces[ss_num][elm][0];
 //     // }
-    
+
 // }
 

--- a/src/cxx/Mesh/Mesh.h
+++ b/src/cxx/Mesh/Mesh.h
@@ -22,8 +22,9 @@
 
 #include <Eigen/Dense>
 
-#include "../Utilities/Options.h"
-#include "../Utilities/Utilities.h"
+#include <Utilities/Options.h>
+#include <Utilities/Utilities.h>
+#include <Utilities/PETScExtensions.h>
 
 /**
  * Struct holding the vectors representing the global DOFs.

--- a/src/cxx/Mesh/Mesh.h
+++ b/src/cxx/Mesh/Mesh.h
@@ -99,6 +99,7 @@ class Mesh {
   void read(Options options);
 
   /**
+   * TODO: MARK FOR DELETION.
    * Sets up the dofs across elements and processor boundaries.
    * Specifcally, this function defines a `DMPlex section` spread across all elements. It is this section that
    * defines the integration points, and carries information about which of these points are shared across processor
@@ -108,12 +109,12 @@ class Mesh {
    * @param [in] number_dof_face Number of dofs per 2-d mesh component (face). (order-1)^2 for the standard GLL basis.
    * @param [in] number_dof_volume Num of dofs per 3-d mesh component (volume). Something something for the
    * standard GLL basis.
+      void setupGlobalDof(PetscInt number_dof_vertex, PetscInt number_dof_edge,
+                          PetscInt number_dof_face, PetscInt number_dof_volume,
+                          PetscInt number_dimensions);
    */
-  void setupGlobalDof(PetscInt number_dof_vertex, PetscInt number_dof_edge,
-                      PetscInt number_dof_face, PetscInt number_dof_volume,
-                      PetscInt number_dimensions);
 
-  PetscErrorCode setupGlobalDofNew();
+  PetscErrorCode setupGlobalDof(int num_dof_vtx, int num_dof_edg, int num_dof_fac, int num_dof_vol, int num_dim);
 
 
   /**

--- a/src/cxx/Mesh/Mesh.h
+++ b/src/cxx/Mesh/Mesh.h
@@ -32,287 +32,298 @@
  * current processor.
  */
 struct vec_struct {
-    std::string name;   /** < Field name (i.e. displacement_x) */
-    Vec glb;            /** < Global PETSc vector */
-    Vec loc;            /** < Local PETSc vector */
+  std::string name;
+  /** < Field name (i.e. displacement_x) */
+  Vec glb;
+  /** < Global PETSc vector */
+  Vec loc;            /** < Local PETSc vector */
 };
 
 class Mesh {
 
-    int mNumberElementsLocal;       /** < Num of elements on this processor. */
-    int mNumberDimensions;          /** < Num of dimensions of the mesh. */
-    int mNumberSideSets;            /** < Num of flagged boundaries. */
+  int mNumberElementsLocal;
+  /** < Num of elements on this processor. */
+  int mNumberDimensions;
+  /** < Num of dimensions of the mesh. */
+  int mNumberSideSets;
+  /** < Num of flagged boundaries. */
 
-    std::string mExodusFileName;    /** < Exodus file from which this mesh (skeleton) was defined. */
+  std::string mExodusFileName;
+  /** < Exodus file from which this mesh (skeleton) was defined. */
 
-    DM mDistributedMesh;            /** < PETSc distributed mesh defining parallel element layout. */
-    PetscSection mMeshSection;      /** < Mesh section describing location of the integration points. In the future we
+  DM mDistributedMesh;
+  /** < PETSc distributed mesh defining parallel element layout. */
+  PetscSection mMeshSection;      /** < Mesh section describing location of the integration points. In the future we
                                         * may have many of these per mesh. */
 
-protected:
+ protected:
 
-    std::vector<std::string> mGlobalFields;     /** < List of field names on global dof ("u","v",etc) */
-    std::map<std::string, vec_struct> mFields;  /** < Dictionary holding the fields on the global dof. */
-    PetscViewer mViewer;                        /** < Holds information used to dump field values to disk. */
+  std::vector<std::string> mGlobalFields;
+  /** < List of field names on global dof ("u","v",etc) */
+  std::map<std::string, vec_struct> mFields;
+  /** < Dictionary holding the fields on the global dof. */
+  PetscViewer mViewer;
+  /** < Holds information used to dump field values to disk. */
 
 
-    std::map<PetscInt, std::string> mBoundaryIds; /** < mapping between boundary id
-                                                      and its associated name (e.g.,
-                                                      "absorbing boundary" in the
-                                                      petsc side set collection) */
-    
-    
-    std::map<std::string,std::map<int,std::vector<int>>>
-        mBoundaryElementFaces;  /** < list of elements on a boundary and the corresponding
+  std::map<PetscInt, std::string> mBoundaryIds;
+  /** < mapping between boundary id
+                                                       and its associated name (e.g.,
+                                                       "absorbing boundary" in the
+                                                       petsc side set collection) */
+
+
+  std::map<std::string, std::map<int, std::vector<int>>>
+      mBoundaryElementFaces;  /** < list of elements on a boundary and the corresponding
                                     boundary faces. Each boundary has its own list of
                                     elements, and each element has its own list of
                                     faces. */
- 
-    
-public:
 
-    /**
-     * Factory which returns a `Mesh` based on user defined options.
-     * The `Mesh` is really a collection of the global dofs, and the fields defined on these dofs will depend on both
-     * the physics of the system under consideration, and the method of time-stepping chosen.
-     * @return Some derived mesh class.
-     */
-    static Mesh *factory(Options options);
 
-    /**
-     * Reads an exodus mesh from a file defined in options.
-     * By the time this method is finished, the mesh has been
-     * read, and parallelized across processors (via a call to Chaco).
-     * @param [in] options The master options struct. TODO: Move the gobbling of options to the constructor.
-     */
-    void read(Options options);
+ public:
 
-    /**
-     * Sets up the dofs across elements and processor boundaries.
-     * Specifcally, this function defines a `DMPlex section` spread across all elements. It is this section that
-     * defines the integration points, and carries information about which of these points are shared across processor
-     * boundries.
-     * @param [in] number_dof_vertex Number of dofs per 0-d mesh component (vertex). 1 for the standard GLL basis.
-     * @param [in] number_dof_edge Number of dofs per 1-d mesh component (edge). order-1 for the standard GLL basis.
-     * @param [in] number_dof_face Number of dofs per 2-d mesh component (face). (order-1)^2 for the standard GLL basis.
-     * @param [in] number_dof_volume Num of dofs per 3-d mesh component (volume). Something something for the
-     * standard GLL basis.
-     */
-    void setupGlobalDof(PetscInt number_dof_vertex, PetscInt number_dof_edge,
-                        PetscInt number_dof_face, PetscInt number_dof_volume,
-                        PetscInt number_dimensions);
+  /**
+   * Factory which returns a `Mesh` based on user defined options.
+   * The `Mesh` is really a collection of the global dofs, and the fields defined on these dofs will depend on both
+   * the physics of the system under consideration, and the method of time-stepping chosen.
+   * @return Some derived mesh class.
+   */
+  static Mesh *factory(Options options);
 
-    /**
-     * Registers both the global (across parallel partition) and local (on a single parallel partition) vectors for a
-     * given name. Vector information is stored in an `std::map` under mFields, with `name` as the key.
-     * @param name Name of field to register.
-     */
-    void registerFieldVectors(const std::string &name);
+  /**
+   * Reads an exodus mesh from a file defined in options.
+   * By the time this method is finished, the mesh has been
+   * read, and parallelized across processors (via a call to Chaco).
+   * @param [in] options The master options struct. TODO: Move the gobbling of options to the constructor.
+   */
+  void read(Options options);
 
-    /**
-     * Begins (and ends) the gloabl -> local MPI sends for a given field name. By the time this function returns, you
-     * can be confident that the MPI sends have been completed (i.e. it is blocking), and will be available to each
-     * element.
-     * @param name Name of field to checkout.
-     */
-    void checkOutField(const std::string &name);
+  /**
+   * Sets up the dofs across elements and processor boundaries.
+   * Specifcally, this function defines a `DMPlex section` spread across all elements. It is this section that
+   * defines the integration points, and carries information about which of these points are shared across processor
+   * boundries.
+   * @param [in] number_dof_vertex Number of dofs per 0-d mesh component (vertex). 1 for the standard GLL basis.
+   * @param [in] number_dof_edge Number of dofs per 1-d mesh component (edge). order-1 for the standard GLL basis.
+   * @param [in] number_dof_face Number of dofs per 2-d mesh component (face). (order-1)^2 for the standard GLL basis.
+   * @param [in] number_dof_volume Num of dofs per 3-d mesh component (volume). Something something for the
+   * standard GLL basis.
+   */
+  void setupGlobalDof(PetscInt number_dof_vertex, PetscInt number_dof_edge,
+                      PetscInt number_dof_face, PetscInt number_dof_volume,
+                      PetscInt number_dimensions);
 
-    /**
-     * Does the local -> global MPI sends for a given field name. The
-     * send is performed with an sum, i.e.  the value of field on
-     * coincident GLL points are properly summed together. 
-     * @param name Name of field to assemble on global dofs.
-     */
-    void assembleLocalFieldToGlobal(const std::string &name);
+  PetscErrorCode setupGlobalDofNew();
 
-    /**
-     * Begins the local -> global MPI sends for a given field name. The
-     * send is performed with an sum, i.e.  the value of field on
-     * coincident GLL points are properly summed together. Note that
-     * this function is non-blocking!! This MUST be paired with an
-     * equivalent call to `assembleLocalFieldToGlobalEnd`.
-     * @param name Name of field to assemble on global dofs.
-     */
-    void assembleLocalFieldToGlobalBegin(const std::string &name);
 
-    /**
-     * Makes a processor local array "global". As a "set", does not incurr any communication.
-     * @param name Name of field to assemble on global dofs.
-     */
-    void setLocalFieldToGlobal(const std::string &name);
-    
-    /**
-     * Finishes the local -> global MPI sends for a given field name. The
-     * send is performed with an sum, i.e.  the value of field on
-     * coincident GLL points are properly summed together. This MUST be paired with an
-     * equivalent call to `assembleLocalFieldToGlobalBegin`.
-     * @param name Name of field to assemble on global dofs.
-     */
-    void assembleLocalFieldToGlobalEnd(const std::string &name);
-        
-    /**
-     * Begins the local -> global MPI sends for a given field name. The send is performed with an implied sum, i.e.
-     * the value of field on coincident GLL points are properly summed together. Note that this function is
-     * non-blocking!! This MUST be paired with an equivalent call to checkInFieldEnd.
-     * @param name Name of field to checkin.
-     */
-    void checkInFieldBegin(const std::string &name);
+  /**
+   * Registers both the global (across parallel partition) and local (on a single parallel partition) vectors for a
+   * given name. Vector information is stored in an `std::map` under mFields, with `name` as the key.
+   * @param name Name of field to register.
+   */
+  void registerFieldVectors(const std::string &name);
 
-    /**
-     * Ends the local -> global MPI send for a given field name. This function should come after an equivalent
-     * checkInFieldBegin. This method is blocking, so you can be confident that when it returns the desired field has
-     * been scattered and summed into the global (parallel) degrees of freedom.
-     * @param name Name of field to checkin.
-     */
-    void checkInFieldEnd(const std::string &name);
+  /**
+   * Begins (and ends) the gloabl -> local MPI sends for a given field name. By the time this function returns, you
+   * can be confident that the MPI sends have been completed (i.e. it is blocking), and will be available to each
+   * element.
+   * @param name Name of field to checkout.
+   */
+  void checkOutField(const std::string &name);
 
-    /**
-     * Returns an ordered vector of a field (i.e. x-displacement) on an element, via a call to DMPlexVecGetClosure.
-     * Note that a vector containing the closure mapping must also be passed in -- this should change in the future.
-     * @param [in] name Name of field.
-     * @param [in] element_number Element number (on the local processor) for which the field is requested.
-     * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
-     * closure to the desired gll point ordering.
-     * @ return The ordered field on an element.
-     */
-    Eigen::VectorXd getFieldOnElement(const std::string &name, const int &element_number,
-                                      const Eigen::VectorXi &closure);
+  /**
+   * Does the local -> global MPI sends for a given field name. The
+   * send is performed with an sum, i.e.  the value of field on
+   * coincident GLL points are properly summed together.
+   * @param name Name of field to assemble on global dofs.
+   */
+  void assembleLocalFieldToGlobal(const std::string &name);
 
-    /**
-     * Returns an ordered vector of a field (i.e. x-displacement) on a face, via a call to
-     * DMPlexVecGetClosure.  Note that a vector containing the closure mapping (for the face) must
-     * also be passed in -- this should change in the future.
-     * @param [in] name Name of field.
-     * @param [in] element_number Element number (on the local processor) for which the field is requested.     
-     * @ return The ordered field on an element.
-     */
-    Eigen::VectorXd getFieldOnFace(const std::string &name, const int &face_number);
-        
-    /**
-     * Sets a field from a face into the degrees of freedom owned by the local processor, via a call to
-     * DMPlexVecSetClosure. Shared DOF should be identical, and are thus set from an arbitrary element.
-     * @param [in] field_name Name of field.
-     * @param [in] face_number Face number (on the local processor) for which the field is requested.
-     * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex face
-     * closure to the desired gll point ordering.
-     * @param [in] field The element-ordered field (i.e. x-displacement) to insert into the mesh.
-     */
-    void setFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field);
+  /**
+   * Begins the local -> global MPI sends for a given field name. The
+   * send is performed with an sum, i.e.  the value of field on
+   * coincident GLL points are properly summed together. Note that
+   * this function is non-blocking!! This MUST be paired with an
+   * equivalent call to `assembleLocalFieldToGlobalEnd`.
+   * @param name Name of field to assemble on global dofs.
+   */
+  void assembleLocalFieldToGlobalBegin(const std::string &name);
 
-    /**
-     * Adds a field from a face into the degrees of freedom owned by the local processor, via a call to
-     * DMPlexVecSetClosure. Shared DOF are "assembled" (added), and are thus a sum from each arbitrary element.
-     * @param [in] field_name Name of field.
-     * @param [in] face_number Face number (on the local processor) for which the field is requested.
-     * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex face
-     * closure to the desired gll point ordering.
-     * @param [in] field The element-ordered field (i.e. x-displacement) to insert into the mesh.
-     */
-    void addFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field);
-    
-    /**
-     * Sets a field from an element into the degrees of freedom owned by the local processor, via a call to
-     * DMPlexVecSetClosure. Shared DOF should be identical, and are thus set from an arbitrary element.
-     * @param [in] field_name Name of field.
-     * @param [in] element_number Element number (on the local processor) for which the field is requested.
-     * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
-     * closure to the desired gll point ordering.
-     * @param [in] field The element-ordered field (i.e. x-displacement) to sum into the mesh.
-     */
-    void setFieldFromElement(const std::string &name, const int element_number,
-                             const Eigen::VectorXi &closure, const Eigen::VectorXd &field);
-    
-    /**
-     * Sums a field from an element into the degrees of freedom owned by the local processor, via a call to
-     * DMPlexVecSetClosure. Shared DOF are summed (i.e., assembled).
-     * @param [in] field_name Name of field.
-     * @param [in] element_number Element number (on the local processor) for which the field is requested.
-     * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
-     * closure to the desired gll point ordering.
-     * @param [in] field The element-ordered field (i.e. x-displacement) to sum into the mesh.
-     */
-    void addFieldFromElement(const std::string &name, const int element_number,
+  /**
+   * Makes a processor local array "global". As a "set", does not incurr any communication.
+   * @param name Name of field to assemble on global dofs.
+   */
+  void setLocalFieldToGlobal(const std::string &name);
+
+  /**
+   * Finishes the local -> global MPI sends for a given field name. The
+   * send is performed with an sum, i.e.  the value of field on
+   * coincident GLL points are properly summed together. This MUST be paired with an
+   * equivalent call to `assembleLocalFieldToGlobalBegin`.
+   * @param name Name of field to assemble on global dofs.
+   */
+  void assembleLocalFieldToGlobalEnd(const std::string &name);
+
+  /**
+   * Begins the local -> global MPI sends for a given field name. The send is performed with an implied sum, i.e.
+   * the value of field on coincident GLL points are properly summed together. Note that this function is
+   * non-blocking!! This MUST be paired with an equivalent call to checkInFieldEnd.
+   * @param name Name of field to checkin.
+   */
+  void checkInFieldBegin(const std::string &name);
+
+  /**
+   * Ends the local -> global MPI send for a given field name. This function should come after an equivalent
+   * checkInFieldBegin. This method is blocking, so you can be confident that when it returns the desired field has
+   * been scattered and summed into the global (parallel) degrees of freedom.
+   * @param name Name of field to checkin.
+   */
+  void checkInFieldEnd(const std::string &name);
+
+  /**
+   * Returns an ordered vector of a field (i.e. x-displacement) on an element, via a call to DMPlexVecGetClosure.
+   * Note that a vector containing the closure mapping must also be passed in -- this should change in the future.
+   * @param [in] name Name of field.
+   * @param [in] element_number Element number (on the local processor) for which the field is requested.
+   * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
+   * closure to the desired gll point ordering.
+   * @ return The ordered field on an element.
+   */
+  Eigen::VectorXd getFieldOnElement(const std::string &name, const int &element_number,
+                                    const Eigen::VectorXi &closure);
+
+  /**
+   * Returns an ordered vector of a field (i.e. x-displacement) on a face, via a call to
+   * DMPlexVecGetClosure.  Note that a vector containing the closure mapping (for the face) must
+   * also be passed in -- this should change in the future.
+   * @param [in] name Name of field.
+   * @param [in] element_number Element number (on the local processor) for which the field is requested.
+   * @ return The ordered field on an element.
+   */
+  Eigen::VectorXd getFieldOnFace(const std::string &name, const int &face_number);
+
+  /**
+   * Sets a field from a face into the degrees of freedom owned by the local processor, via a call to
+   * DMPlexVecSetClosure. Shared DOF should be identical, and are thus set from an arbitrary element.
+   * @param [in] field_name Name of field.
+   * @param [in] face_number Face number (on the local processor) for which the field is requested.
+   * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex face
+   * closure to the desired gll point ordering.
+   * @param [in] field The element-ordered field (i.e. x-displacement) to insert into the mesh.
+   */
+  void setFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field);
+
+  /**
+   * Adds a field from a face into the degrees of freedom owned by the local processor, via a call to
+   * DMPlexVecSetClosure. Shared DOF are "assembled" (added), and are thus a sum from each arbitrary element.
+   * @param [in] field_name Name of field.
+   * @param [in] face_number Face number (on the local processor) for which the field is requested.
+   * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex face
+   * closure to the desired gll point ordering.
+   * @param [in] field The element-ordered field (i.e. x-displacement) to insert into the mesh.
+   */
+  void addFieldFromFace(const std::string &name, const int face_number, const Eigen::VectorXd &field);
+
+  /**
+   * Sets a field from an element into the degrees of freedom owned by the local processor, via a call to
+   * DMPlexVecSetClosure. Shared DOF should be identical, and are thus set from an arbitrary element.
+   * @param [in] field_name Name of field.
+   * @param [in] element_number Element number (on the local processor) for which the field is requested.
+   * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
+   * closure to the desired gll point ordering.
+   * @param [in] field The element-ordered field (i.e. x-displacement) to sum into the mesh.
+   */
+  void setFieldFromElement(const std::string &name, const int element_number,
                            const Eigen::VectorXi &closure, const Eigen::VectorXd &field);
-    
-    /**
-     * Number of elements owned by the current processors.
-     * @ return Num of Elements.
-     */
-    inline PetscInt NumberElementsLocal() { return mNumberElementsLocal; }
 
-    /**
-     * Defines the field to visualize, and the name of the file to dump to.
-     * @param [in] movie_filename Where to save the file.
-     * TODO: Should add field name here, and interval? Do we need to support other dump options than HDF5?
-     */
-    void setUpMovie(const std::string &movie_filename);
+  /**
+   * Sums a field from an element into the degrees of freedom owned by the local processor, via a call to
+   * DMPlexVecSetClosure. Shared DOF are summed (i.e., assembled).
+   * @param [in] field_name Name of field.
+   * @param [in] element_number Element number (on the local processor) for which the field is requested.
+   * @param [in] closure A vector of size mNumIntPnt, which specifies the mapping from the Plex element
+   * closure to the desired gll point ordering.
+   * @param [in] field The element-ordered field (i.e. x-displacement) to sum into the mesh.
+   */
+  void addFieldFromElement(const std::string &name, const int element_number,
+                           const Eigen::VectorXi &closure, const Eigen::VectorXd &field);
 
-    /**
-     * Commits a movie frame to disk, using the interface defined in setUpMovie.
-     */
-    void saveFrame(std::string name, PetscInt timestep);
+  /**
+   * Number of elements owned by the current processors.
+   * @ return Num of Elements.
+   */
+  inline PetscInt NumberElementsLocal() { return mNumberElementsLocal; }
 
-    /**
-     * Needs to be called at the end of a time loop if a movie is desired.
-     * Cleans up the open HDF5 file, and safely shuts down the output stream.
-     */
-    void finalizeMovie();
+  /**
+   * Defines the field to visualize, and the name of the file to dump to.
+   * @param [in] movie_filename Where to save the file.
+   * TODO: Should add field name here, and interval? Do we need to support other dump options than HDF5?
+   */
+  void setUpMovie(const std::string &movie_filename);
 
-    /**
-     * Set a desired vec_struct to zero. Usefull for those terms which we sum into (i.e. element forcing).
-     */
-    void zeroFields(const std::string &name);
+  /**
+   * Commits a movie frame to disk, using the interface defined in setUpMovie.
+   */
+  void saveFrame(std::string name, PetscInt timestep);
 
-    /**
-     * Read and setup boundaries (exodus side sets). Gets list of faces from Petsc and builds
-     * corresponding list of elements, which lay on each boundary.
-     */
-    int setupBoundaries(Options options);
+  /**
+   * Needs to be called at the end of a time loop if a movie is desired.
+   * Cleans up the open HDF5 file, and safely shuts down the output stream.
+   */
+  void finalizeMovie();
 
-    /**
-     * Reads boundaries (exodus side sets) from mesh file and builds appropriate boundary name to
-     * petsc id mapping.
-     */
-    int readBoundaryNames(Options options);
-    
-    /**
-     * Virtual function which implements the time stepping.
-     * This will change based on physics, time stepping routine, and dimension.
-     */
-    virtual void advanceField(double dt) = 0;
+  /**
+   * Set a desired vec_struct to zero. Usefull for those terms which we sum into (i.e. element forcing).
+   */
+  void zeroFields(const std::string &name);
 
-    /**
-     * Virtual function to apply the inverse of a mass matrix.
-     * This is usually called at the beginning of a time loop. Again, it will depend on the specific physics and
-     * time scheme used. When this function is complete, the global fields should be ready to take a time-step (at
-     * least that's the case for explicit schemes).
-     */
-    virtual void applyInverseMassMatrix() = 0;
+  /**
+   * Read and setup boundaries (exodus side sets). Gets list of faces from Petsc and builds
+   * corresponding list of elements, which lay on each boundary.
+   */
+  int setupBoundaries(Options options);
 
-    /**
-     * Return list of all the fields required on the global degrees of freedom.
-     */
-    std::vector<std::string> GlobalFields() const { return mGlobalFields; }
+  /**
+   * Reads boundaries (exodus side sets) from mesh file and builds appropriate boundary name to
+   * petsc id mapping.
+   */
+  int readBoundaryNames(Options options);
 
-    /**
-     * Add field to list of global degrees of freedom. Has to be done
-     * before mesh initializes fields to global DOF. (via registerFieldVectors)
-     */
-    void AddToGlobalFields(std::string fieldname) { mGlobalFields.push_back(fieldname); }
-    
+  /**
+   * Virtual function which implements the time stepping.
+   * This will change based on physics, time stepping routine, and dimension.
+   */
+  virtual void advanceField(double dt) = 0;
 
-    
-    inline DM &DistributedMesh() { return mDistributedMesh; }
-    inline PetscSection &MeshSection() { return mMeshSection; }
-    virtual std::map<PetscInt, std::string>& BoundaryIds() { return mBoundaryIds; }
+  /**
+   * Virtual function to apply the inverse of a mass matrix.
+   * This is usually called at the beginning of a time loop. Again, it will depend on the specific physics and
+   * time scheme used. When this function is complete, the global fields should be ready to take a time-step (at
+   * least that's the case for explicit schemes).
+   */
+  virtual void applyInverseMassMatrix() = 0;
 
-    inline int NumberSideSets() { return mNumberSideSets; }
-    inline int NumberDimensions() { return mNumberDimensions; }
+  /**
+   * Return list of all the fields required on the global degrees of freedom.
+   */
+  std::vector<std::string> GlobalFields() const { return mGlobalFields; }
 
-    inline std::map<std::string,std::map<int,std::vector<int>>>
-        BoundaryElementFaces() { return mBoundaryElementFaces; }
+  /**
+   * Add field to list of global degrees of freedom. Has to be done
+   * before mesh initializes fields to global DOF. (via registerFieldVectors)
+   */
+  void AddToGlobalFields(std::string fieldname) { mGlobalFields.push_back(fieldname); }
 
 
+  inline DM &DistributedMesh() { return mDistributedMesh; }
+  inline PetscSection &MeshSection() { return mMeshSection; }
+  virtual std::map<PetscInt, std::string> &BoundaryIds() { return mBoundaryIds; }
+
+  inline int NumberSideSets() { return mNumberSideSets; }
+  inline int NumberDimensions() { return mNumberDimensions; }
+
+  inline std::map<std::string, std::map<int, std::vector<int>>>
+  BoundaryElementFaces() { return mBoundaryElementFaces; }
 
 };
 

--- a/src/cxx/Problem/NewmarkGeneral.cpp
+++ b/src/cxx/Problem/NewmarkGeneral.cpp
@@ -16,12 +16,11 @@ void NewmarkGeneral::initialize(Mesh *mesh,
   mReferenceElem = elem;
 
   // Attach elements to mesh.
-//  mMesh->setupGlobalDof(mReferenceElem->NumDofVtx(),
-//                        mReferenceElem->NumDofEdg(),
-//                        mReferenceElem->NumDofFac(),
-//                        0 /* zero dofvolume */,
-//                        mReferenceElem->NumDim());
-  mMesh->setupGlobalDofNew();
+  mMesh->setupGlobalDof(mReferenceElem->NumDofVtx(),
+                        mReferenceElem->NumDofEdg(),
+                        mReferenceElem->NumDofFac(),
+                        mReferenceElem->NumDofVol(),
+                        mReferenceElem->NumDim());
 
   // Setup boundary conditions from options.
   mMesh->setupBoundaries(options);

--- a/src/cxx/Problem/NewmarkGeneral.cpp
+++ b/src/cxx/Problem/NewmarkGeneral.cpp
@@ -16,11 +16,12 @@ void NewmarkGeneral::initialize(Mesh *mesh,
   mReferenceElem = elem;
 
   // Attach elements to mesh.
-  mMesh->setupGlobalDof(mReferenceElem->NumDofVtx(),
-                        mReferenceElem->NumDofEdg(),
-                        mReferenceElem->NumDofFac(),
-                        0 /* zero dofvolume */,
-                        mReferenceElem->NumDim());
+//  mMesh->setupGlobalDof(mReferenceElem->NumDofVtx(),
+//                        mReferenceElem->NumDofEdg(),
+//                        mReferenceElem->NumDofFac(),
+//                        0 /* zero dofvolume */,
+//                        mReferenceElem->NumDim());
+  mMesh->setupGlobalDofNew();
 
   // Setup boundary conditions from options.
   mMesh->setupBoundaries(options);

--- a/src/cxx/Problem/NewmarkTesting.cpp
+++ b/src/cxx/Problem/NewmarkTesting.cpp
@@ -13,7 +13,7 @@ void NewmarkTesting::initialize(Mesh *mesh,
     mMesh->setupGlobalDof(mReferenceElem->NumDofVtx(),
                           mReferenceElem->NumDofEdg(),
                           mReferenceElem->NumDofFac(),
-                          0 /* zero dofvolume */,
+                          mReferenceElem->NumDofVol(),
                           mReferenceElem->NumDim());
 
     // Setup boundary conditions from options.

--- a/src/cxx/Testing/test_exactsolution.cpp
+++ b/src/cxx/Testing/test_exactsolution.cpp
@@ -12,12 +12,12 @@ int initialize_exact(Mesh *mesh,
     
     PetscFunctionBegin;
 
-    // Attach elements to mesh.
-    mesh->setupGlobalDof(reference_element->NumDofVtx(),
-                         reference_element->NumDofEdg(),
-                         reference_element->NumDofFac(),
-                          0 /* zero dofvolume */,
-                         reference_element->NumDim());
+  // Setup the dofs on each mesh point.
+  mesh->setupGlobalDof(reference_element->NumDofVtx(),
+                       reference_element->NumDofEdg(),
+                       reference_element->NumDofFac(),
+                       reference_element->NumDofVol(),
+                       reference_element->NumDim());
 
     // Setup boundary conditions from options.
     mesh->setupBoundaries(options);
@@ -240,7 +240,7 @@ TEST_CASE("Testing acoustic exact solutions for quadrilaterals", "[exact/quads]"
     options.__SetCenter_z(0.0);
     options.__SetSquareSide_L(2.0);
     options.__SetSaveMovie(PETSC_FALSE);
-    
+
     // Get mesh.
     Mesh *mesh = Mesh::factory(options);
     mesh->read(options);

--- a/src/cxx/Utilities/PETScExtensions.c
+++ b/src/cxx/Utilities/PETScExtensions.c
@@ -1,0 +1,238 @@
+#include "PETScExtensions.h"
+
+/* closure helpers */
+#undef __FUNCT__
+#define __FUNCT__ "_DMPlexVecGetClosure_Depth1_Static_GetIndices"
+PetscErrorCode _DMPlexVecGetClosure_Depth1_Static_GetIndices(DM dm, PetscSection section, PetscInt point, PetscInt *csize, PetscInt *idx[])
+{
+  PetscInt       *ilist;
+  const PetscInt *cone, *coneO;
+  PetscInt        pStart, pEnd, p, numPoints, size = 0, offset = 0;
+  PetscErrorCode  ierr;
+
+  ierr = PetscSectionGetChart(section, &pStart, &pEnd);CHKERRQ(ierr);
+  ierr = DMPlexGetConeSize(dm, point, &numPoints);CHKERRQ(ierr);
+  ierr = DMPlexGetCone(dm, point, &cone);CHKERRQ(ierr);
+  ierr = DMPlexGetConeOrientation(dm, point, &coneO);CHKERRQ(ierr);
+  {
+    if ((point >= pStart) && (point < pEnd)) {
+      PetscInt dof;
+
+      ierr = PetscSectionGetDof(section, point, &dof);CHKERRQ(ierr);
+      size += dof;
+    }
+    for (p = 0; p < numPoints; ++p) {
+      const PetscInt cp = cone[p];
+      PetscInt       dof;
+
+      if ((cp < pStart) || (cp >= pEnd)) continue;
+      ierr = PetscSectionGetDof(section, cp, &dof);CHKERRQ(ierr);
+      size += dof;
+    }
+
+    PetscMalloc1(size,&ilist);
+  }
+
+  size = 0;
+  if ((point >= pStart) && (point < pEnd)) {
+    PetscInt     dof, off, d;
+
+    ierr = PetscSectionGetDof(section, point, &dof);CHKERRQ(ierr);
+    ierr = PetscSectionGetOffset(section, point, &off);CHKERRQ(ierr);
+    for (d = 0; d < dof; ++d, ++offset) {
+      ilist[offset] = off + d;
+    }
+    size += dof;
+  }
+  for (p = 0; p < numPoints; ++p) {
+    const PetscInt cp = cone[p];
+    PetscInt       o  = coneO[p];
+    PetscInt       dof, off, d;
+    PetscScalar   *varr;
+
+    if ((cp < pStart) || (cp >= pEnd)) continue;
+    ierr = PetscSectionGetDof(section, cp, &dof);CHKERRQ(ierr);
+    ierr = PetscSectionGetOffset(section, cp, &off);CHKERRQ(ierr);
+    if (o >= 0) {
+      for (d = 0; d < dof; ++d, ++offset) {
+        ilist[offset] = off + d;
+      }
+    } else {
+      for (d = dof-1; d >= 0; --d, ++offset) {
+        ilist[offset] = off + d;
+      }
+    }
+    size += dof;
+  }
+
+  *csize = size;
+  *idx = ilist;
+
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "_DMPlexVecGetClosure_Fields_Static_GetIndices"
+PetscErrorCode _DMPlexVecGetClosure_Fields_Static_GetIndices(PetscSection section, PetscInt numPoints, const PetscInt points[], PetscInt numFields, PetscInt *size, PetscInt idx[])
+{
+  PetscInt       offset = 0, f;
+  PetscErrorCode ierr;
+
+  *size = 0;
+  for (f = 0; f < numFields; ++f) {
+    PetscInt fcomp, p;
+
+    ierr = PetscSectionGetFieldComponents(section, f, &fcomp);CHKERRQ(ierr);
+    for (p = 0; p < numPoints*2; p += 2) {
+      const PetscInt point = points[p];
+      const PetscInt o     = points[p+1];
+      PetscInt       fdof, foff, d, c;
+
+      ierr = PetscSectionGetFieldDof(section, point, f, &fdof);CHKERRQ(ierr);
+      ierr = PetscSectionGetFieldOffset(section, point, f, &foff);CHKERRQ(ierr);
+      if (o >= 0) {
+        for (d = 0; d < fdof; ++d, ++offset) idx[offset] = foff + d;
+      } else {
+        for (d = fdof/fcomp-1; d >= 0; --d) {
+          for (c = 0; c < fcomp; ++c, ++offset) {
+            idx[offset] = foff + d*fcomp+c;
+          }
+        }
+      }
+    }
+  }
+  *size = offset;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "_DMPlexVecGetClosure_Static_GetIndices"
+PetscErrorCode _DMPlexVecGetClosure_Static_GetIndices(PetscSection section, PetscInt numPoints, const PetscInt points[], PetscInt *size, PetscInt idx[])
+{
+  PetscInt       offset = 0, p;
+  PetscErrorCode ierr;
+
+  *size = 0;
+  for (p = 0; p < numPoints*2; p += 2) {
+    const PetscInt point = points[p];
+    const PetscInt o     = points[p+1];
+    PetscInt       dof, off, d;
+
+    ierr = PetscSectionGetDof(section, point, &dof);CHKERRQ(ierr);
+    ierr = PetscSectionGetOffset(section, point, &off);CHKERRQ(ierr);
+    if (o >= 0) {
+      for (d = 0; d < dof; ++d, ++offset)    idx[offset] = off + d;
+    } else {
+      for (d = dof-1; d >= 0; --d, ++offset) idx[offset] = off + d;
+    }
+  }
+  *size = offset;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "DMPlexGetClosureIndices"
+PetscErrorCode DMPlexGetClosureIndices(DM dm, PetscSection section, PetscInt point, PetscInt *csize, PetscInt *idx[])
+{
+  PetscSection    clSection;
+  IS              clPoints;
+  PetscInt       *points = NULL;
+  PetscInt       *ilist;
+  const PetscInt *clp;
+  PetscInt        depth, numFields, numPoints, size;
+  PetscErrorCode  ierr;
+
+  if (!csize) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a pointer to csize");
+  if (!idx) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a pointer to idx");
+  if (!section) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a PetscSection");
+
+  ierr = DMPlexGetDepth(dm, &depth);CHKERRQ(ierr);
+  ierr = PetscSectionGetNumFields(section, &numFields);CHKERRQ(ierr);
+  if (depth == 1 && numFields < 2) {
+    ierr = _DMPlexVecGetClosure_Depth1_Static_GetIndices(dm, section, point, csize, idx);CHKERRQ(ierr);
+    PetscFunctionReturn(0);
+  }
+  /* Get points */
+  ierr = PetscSectionGetClosureIndex(section, (PetscObject) dm, &clSection, &clPoints);CHKERRQ(ierr);
+  if (!clPoints) {
+    PetscInt pStart, pEnd, p, q;
+
+    ierr = PetscSectionGetChart(section, &pStart, &pEnd);CHKERRQ(ierr);
+    ierr = DMPlexGetTransitiveClosure(dm, point, PETSC_TRUE, &numPoints, &points);CHKERRQ(ierr);
+    /* Compress out points not in the section */
+    for (p = 0, q = 0; p < numPoints*2; p += 2) {
+      if ((points[p] >= pStart) && (points[p] < pEnd)) {
+        points[q*2]   = points[p];
+        points[q*2+1] = points[p+1];
+        ++q;
+      }
+    }
+    numPoints = q;
+  } else {
+    PetscInt dof, off;
+
+    ierr = PetscSectionGetDof(clSection, point, &dof);CHKERRQ(ierr);
+    ierr = PetscSectionGetOffset(clSection, point, &off);CHKERRQ(ierr);
+    ierr = ISGetIndices(clPoints, &clp);CHKERRQ(ierr);
+    numPoints = dof/2;
+    points    = (PetscInt *) &clp[off];
+  }
+
+  /* Get array */
+  {
+    PetscInt asize = 0, dof, p;
+
+    for (p = 0; p < numPoints*2; p += 2) {
+      ierr = PetscSectionGetDof(section, points[p], &dof);CHKERRQ(ierr);
+      asize += dof;
+    }
+    *csize = asize;
+    PetscMalloc1(asize,&ilist);
+  }
+
+  /* Get values  - Reimplemeneted as GetIndices */
+  if (numFields > 0) {ierr = _DMPlexVecGetClosure_Fields_Static_GetIndices(section, numPoints, points, numFields, &size, ilist);CHKERRQ(ierr);}
+  else               {ierr = _DMPlexVecGetClosure_Static_GetIndices(section, numPoints, points, &size, ilist);CHKERRQ(ierr);}
+  /* Cleanup points */
+  if (!clPoints) {ierr = DMPlexRestoreTransitiveClosure(dm, point, PETSC_TRUE, &numPoints, &points);CHKERRQ(ierr);}
+  else           {ierr = ISRestoreIndices(clPoints, &clp);CHKERRQ(ierr);}
+
+  if (size > *csize) SETERRQ2(PETSC_COMM_SELF, PETSC_ERR_ARG_OUTOFRANGE, "Size of input array %d < actual size %d", *csize, size);
+
+  *csize = size;
+  *idx = ilist;
+
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "DMPlexGetClosureWorkArray"
+PetscErrorCode DMPlexGetClosureWorkArray(DM dm,PetscInt npoints,PetscSection section,PetscInt *bsize,PetscScalar **buffer)
+{
+  PetscErrorCode ierr;
+  PetscInt e,max,size;
+  PetscScalar *array;
+  Vec u;
+
+  if (!section) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a valid PetscSection");
+  if (!bsize) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a pointer to bsize");
+  if (!buffer) SETERRQ(PetscObjectComm((PetscObject)dm),PETSC_ERR_USER,"Must provide a pointer to the work buffer");
+
+  ierr = DMGetLocalVector(dm,&u);CHKERRQ(ierr);
+  max = PETSC_MIN_INT;
+  for (e=0; e<npoints; e++) {
+    PetscScalar *vals = NULL;
+
+    ierr = DMPlexVecGetClosure(dm,section,u,e,&size,&vals);CHKERRQ(ierr);
+    ierr = DMPlexVecRestoreClosure(dm,section,u,e,&size,&vals);CHKERRQ(ierr);
+    if (size > max) { max = size; }
+  }
+  ierr = DMRestoreLocalVector(dm,&u);CHKERRQ(ierr);
+
+  PetscMalloc1(max,&array);
+  *bsize = max;
+  *buffer = array;
+
+  PetscFunctionReturn(0);
+}
+

--- a/src/cxx/Utilities/PETScExtensions.h
+++ b/src/cxx/Utilities/PETScExtensions.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <petsc.h>
+
+PetscErrorCode _DMPlexVecGetClosure_Depth1_Static_GetIndices(
+    DM dm, PetscSection section, PetscInt point, PetscInt *csize, PetscInt *idx[]);
+
+PetscErrorCode _DMPlexVecGetClosure_Fields_Static_GetIndices(
+    PetscSection section, PetscInt numPoints, const PetscInt points[],
+    PetscInt numFields, PetscInt *size, PetscInt idx[]);
+
+PetscErrorCode _DMPlexVecGetClosure_Static_GetIndices(
+    PetscSection section, PetscInt numPoints, const PetscInt points[], PetscInt *size,
+    PetscInt idx[]);
+
+PetscErrorCode DMPlexGetClosureIndices(DM dm, PetscSection section, PetscInt point,
+                                       PetscInt *csize, PetscInt *idx[]);
+
+PetscErrorCode DMPlexGetClosureWorkArray(DM dm, PetscInt npoints,PetscSection section,
+                                         PetscInt *bsize, PetscScalar **buffer);
+
+
+
+
+


### PR DESCRIPTION
Replacing the generic `PetscSection` construction with a re-work of Dave's. This allows us to define a custom number of DOFs at each grid point. Currently, it reproduces the same results as if we had called the generic setup routines.