### PR TITLE
Added test coverage for the mesh class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,8 @@ add_executable(salvus_test
         src/cxx/Testing/test_Quad_Scalar_2D.cpp
         src/cxx/Testing/test_TensorHex.cpp
         src/cxx/Testing/test_receiver.cpp
-        src/cxx/Testing/test_Element.cpp)
+        src/cxx/Testing/test_Element.cpp
+        src/cxx/Testing/test_Mesh.cpp)
 
 # run `make` (or `make -j5`) to build `salvus` executable
 target_link_libraries(salvus salvusCommon ${MPI_LIBRARIES} petsc exodus netcdf hdf5)

--- a/include/Problem/Order2Newmark.h
+++ b/include/Problem/Order2Newmark.h
@@ -9,6 +9,13 @@ class Order2Newmark: public Problem {
 
  public:
 
+  /**
+   * Returns individual field components for a given physical system.
+   * @param physics "fluid", or "elastic2d" or "elastic3d", etc.
+   * @return The defined fields (i.e. u, ux, uy, uz, ...
+   */
+  static std::vector<std::string> physicsToFields(const std::set<std::string> &physics);
+
   Order2Newmark(const std::unique_ptr<Options>& options);
   FieldDict initializeGlobalDofs(ElemVec const &elements, std::unique_ptr<Mesh> &mesh);
   FieldDict applyInverseMassMatrix(FieldDict fields);

--- a/src/cxx/Element/Element.cpp
+++ b/src/cxx/Element/Element.cpp
@@ -21,10 +21,11 @@
 #include <Utilities/Logging.h>
 #include <Physics/HomogeneousDirichlet.h>
 
-enum elem_code { eQuad, eHex };
+enum elem_code { eQuad, eHex, eTypeError };
 elem_code etype(const std::string &etype) {
   if (etype == "quad") return eQuad;
   if (etype == "hex")  return eHex;
+  return eTypeError;
 }
 
 enum phys_code {
@@ -236,7 +237,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                                    "Coupling physics: " + couple);
       }
 
-    default:
+    case eTypeError:
       break;
 
   }

--- a/src/cxx/Mesh/Mesh.cpp
+++ b/src/cxx/Mesh/Mesh.cpp
@@ -17,17 +17,10 @@ extern "C" {
 
 using std::unique_ptr;
 
-void exodusError(const int retval, std::string func_name) {
-
-  if (retval) {
-    throw std::runtime_error("Error in exodus function: " + func_name);
-  }
-
-}
-
 Mesh::Mesh(const std::unique_ptr<Options> &options) {
   mExodusFileName = options->MeshFile();
   mDistributedMesh = NULL;
+  mMeshSection = NULL;
 }
 
 std::unique_ptr<Mesh> Mesh::Factory(const std::unique_ptr<Options> &options) {
@@ -44,8 +37,7 @@ void Mesh::read() {
   if (rank == 0) {
     std::ifstream f(mExodusFileName.c_str());
     if (!f.good()) {
-      LOG() << "ERROR: Mesh " << mExodusFileName << " does not exist!";
-      MPI_Abort(PETSC_COMM_WORLD, -1);
+      throw std::runtime_error("Mesh file not found! You requested '" + mExodusFileName + "'.");
     }
   }
   MPI_Barrier(PETSC_COMM_WORLD);
@@ -54,20 +46,19 @@ void Mesh::read() {
   DM dm = NULL;
   PetscBool interpolate_edges = PETSC_TRUE;
 
-  // Read exodus file.
+  /* Read exodus file. */
   DMPlexCreateExodusFromFile(PETSC_COMM_WORLD, mExodusFileName.c_str(), interpolate_edges, &dm);
 
-  // May be a race condition on distribute.
-  MPI_Barrier(PETSC_COMM_WORLD);
+  /* Distribute mesh. */
   DMPlexDistribute(dm, 0, NULL, &mDistributedMesh);
 
-  // We don't need the serial mesh anymore.
+  /* We don't need the serial mesh anymore if we're in parallel. */
   if (mDistributedMesh) { DMDestroy(&dm); }
-    // mDistributedMesh == NULL when only 1 proc is used.
   else { mDistributedMesh = dm; }
 
   DMGetDimension(mDistributedMesh, &mNumDim);
   DMPlexGetDepthStratum(mDistributedMesh, mNumDim, NULL, &mNumberElementsLocal);
+
 }
 
 void Mesh::setupGlobalDof(unique_ptr<ExodusModel> const &model, unique_ptr<Options> const &options) {
@@ -145,31 +136,17 @@ void Mesh::setupGlobalDof(unique_ptr<ExodusModel> const &model, unique_ptr<Optio
   DMSetDefaultSection(mDistributedMesh, mMeshSection);
   DMPlexCreateSpectralClosurePermutation(mDistributedMesh, NULL);
 
-  /* Map the physics type to global field names. */
-  for (auto &p: mMeshFields) {
-    for (auto &f: appendPhysicalFields({}, p)) {
-      mGlobalFields.push_back(f);
-    }
-  }
-
 }
 
 std::vector<PetscInt> Mesh::EdgeNumbers(const PetscInt elm) {
 
   std::vector<PetscInt> edges;
-  PetscInt num_pts, e_start, e_end, *points = NULL, dep_edge = 1;
-  DMPlexGetTransitiveClosure(mDistributedMesh, elm, PETSC_TRUE, &num_pts, &points);
-  // get range of values which define edges.
-  DMPlexGetDepthStratum(mDistributedMesh, dep_edge, &e_start, &e_end);
-  for (PetscInt i = 0; i < num_pts; i++) {
-    PetscInt pnt = points[2*i];
-    // if edge is in closure, push it back.
-    if (pnt >= e_start && pnt < e_end) {
-      edges.push_back(pnt);
-    }
-  }
-  DMPlexRestoreTransitiveClosure(mDistributedMesh, elm, PETSC_TRUE, &num_pts, &points);
+  /* Step up one level in the graph (reduce dim). */
+  PetscInt csize; DMPlexGetConeSize(mDistributedMesh, elm, &csize);
+  const PetscInt *cone; DMPlexGetCone(mDistributedMesh, elm, &cone);
+  for (PetscInt i = 0; i < csize; i++) { edges.push_back(cone[i]); }
   return edges;
+
 }
 
 PetscInt Mesh::GetNeighbouringElement(const PetscInt interface, const PetscInt this_elm) const {
@@ -180,7 +157,9 @@ PetscInt Mesh::GetNeighbouringElement(const PetscInt interface, const PetscInt t
   for (PetscInt i = 0; i < ssize; i++) {
     if (supp[i] != this_elm) { neighbour = supp[i]; }
   }
-  assert(neighbour != -1);
+  if (neighbour == -1) { throw std::runtime_error(
+        "Element " + std::to_string(this_elm) + " has no neighbour on face "
+                   + std::to_string(interface)); }
   return neighbour;
 
 }
@@ -249,42 +228,17 @@ Eigen::MatrixXd Mesh::getElementCoordinateClosure(PetscInt elem_num) {
 
 }
 
-std::vector<std::string> Mesh::appendPhysicalFields(const std::vector<std::string>& fields,
-                                                    const std::string& physics) {
-
-  /* TODO: Move this to problem. */
-  std::vector<std::string> new_fields;
-  if (physics == "fluid") {
-    new_fields = {"u", "v", "a", "a_"};
-  } else if (physics == "2delastic") {
-    new_fields = {"ux", "uy"};
-  } else if (physics == "3delastic") {
-    new_fields = {"ux", "uy", "uz"};
-  } else {
-    LOG() << "ERROR IN FIELD TYPE " + physics;
-    MPI_Abort(PETSC_COMM_WORLD, -1);
-  }
-
-  for (auto &f: fields) { new_fields.push_back(f); }
-  return new_fields;
-
-}
-
-int Mesh::numFieldPerPhysics(std::string physics) {
-  int num;
-  try {
+PetscInt Mesh::numFieldPerPhysics(std::string physics) {
+  PetscInt num;
     if (physics == "fluid") { num = 1; }
     else if (physics == "2delastic") { num = 2; }
     else if (physics == "3delastic") { num = 3; }
     else {
       throw std::runtime_error("Derived type " + physics + " is not known.");
     }
-  } catch (std::exception &e) {
-    LOG() << e.what();
-    MPI_Abort(PETSC_COMM_WORLD, -1);
-  }
   return num;
 }
+
 std::string Mesh::baseElementType() {
   std::string type;
   RealMat vtx = getElementCoordinateClosure(0);

--- a/src/cxx/Problem/Problem.cpp
+++ b/src/cxx/Problem/Problem.cpp
@@ -308,10 +308,3 @@ RealVec Problem::getFieldOnElement(const std::string &name,
   return field;
 
 }
-
-
-
-
-
-
-

--- a/src/cxx/Testing/test_Element.cpp
+++ b/src/cxx/Testing/test_Element.cpp
@@ -60,6 +60,8 @@ TEST_CASE("Test to make sure proper elements are returned.", "[element]") {
   REQUIRE_THROWS_AS(Element::Factory("hex", {"3delastic", "fluid", "boundary"}, {}, options)->Name(),
                     std::runtime_error);
 
+  REQUIRE_THROWS_AS(Element::Factory("quad", {"fluid"}, {"cat", "dog", "korbinian"}, options)->Name(),
+                    std::runtime_error);
   REQUIRE_THROWS_AS(Element::Factory("quad", {"2delastic"}, {"cat", "dog", "korbinian"}, options)->Name(),
                     std::runtime_error);
   REQUIRE_THROWS_AS(Element::Factory("hex", {"3delastic"}, {"fluid", "boundary", "dog"}, options)->Name(),

--- a/src/cxx/Testing/test_Mesh.cpp
+++ b/src/cxx/Testing/test_Mesh.cpp
@@ -1,0 +1,201 @@
+#include <iostream>
+#include <salvus.h>
+#include "catch.h"
+
+
+TEST_CASE("Unit test mesh", "[mesh]") {
+
+  PetscOptionsClear(NULL);
+  const char *arg[] = {
+      "salvus_test",
+      "--testing", "true",
+      "--mesh-file", "quad_eigenfunction",
+      "--polynomial-order", "1", NULL};
+
+  /* Fake setting via command line. */
+  char **argv = const_cast<char **> (arg);
+  int argc = sizeof(arg) / sizeof(const char *) - 1;
+  PetscOptionsInsert(NULL, &argc, &argv, NULL);
+
+  SECTION("Fail with non-existant mesh file.") {
+    /* Start with the wrong mesh name. */
+    std::unique_ptr<Options> options(new Options);
+    options->setOptions();
+    auto mesh = Mesh::Factory(options);
+    REQUIRE_THROWS_AS(mesh->read(), std::runtime_error);
+  }
+
+  SECTION("Correctly initialize DM (2D quad).") {
+
+    PetscOptionsSetValue(NULL, "--mesh-file", "quad_eigenfunction.e");
+    PetscOptionsSetValue(NULL, "--model-file", "quad_eigenfunction.e");
+    std::unique_ptr<Options> options(new Options);
+    options->setOptions();
+
+    /* Ensure mesh was read. */
+    auto mesh = Mesh::Factory(options);
+    mesh->read();
+    REQUIRE(mesh->DistributedMesh() != NULL);
+
+    /* Attach model and global dofs. */
+    std::unique_ptr<ExodusModel> model(new ExodusModel(options));
+    model->read();
+    mesh->setupGlobalDof(model, options);
+    REQUIRE(mesh->MeshSection() != NULL);
+
+    /* Ensure vertices are correct. */
+    QuadVtx vtx; vtx << 0, 0, 25000, 0, 25000, 25000, 0, 25000;
+    REQUIRE(mesh->getElementCoordinateClosure(0).isApprox(vtx));
+
+    /* Ensure edges are consistent. */
+    std::vector<PetscInt> true_edges = { 41, 42, 43, 44 };
+    REQUIRE(mesh->EdgeNumbers(0) == true_edges);
+
+    /* Ensure neighbouring element are consistent. */
+    REQUIRE_THROWS_AS(mesh->GetNeighbouringElement(41, 0), std::runtime_error);
+    REQUIRE_THROWS_AS(mesh->GetNeighbouringElement(44, 0), std::runtime_error);
+    REQUIRE(mesh->GetNeighbouringElement(42, 0) == 1);
+    REQUIRE(mesh->GetNeighbouringElement(43, 0) == 4);
+
+    /* Ensure that we only return the physics of our neighbours. */
+    REQUIRE(mesh->CouplingFields((0)).size() == 2);
+    REQUIRE(mesh->CouplingFields((1)).size() == 3);
+    REQUIRE(mesh->CouplingFields((5)).size() == 4);
+
+    /* Ensure that we can get the proper physics from neighbour elements. */
+    for (auto &f: mesh->CouplingFields(0)) {
+      REQUIRE(std::get<1>(f).size() == 1);
+      REQUIRE(std::get<1>(f)[0] == "fluid");
+    }
+
+    /* Ensure that we get the proper physics for our element. */
+    REQUIRE(mesh->ElementFields(0)[0] == "fluid");
+
+    /* Ensure that, if we're on a boundary, we can detect that. */
+    REQUIRE(mesh->TotalCouplingFields(0)[0] == "boundary");
+
+    /* Ensure that if we're in the middle of a homogeneous section, there's no coupling. */
+    REQUIRE(mesh->TotalCouplingFields(5).empty());
+
+    /* Make sure we know we're a quad. */
+    REQUIRE(mesh->baseElementType() == "quad");
+
+    /* Make sure we have the correct number of elements. */
+    REQUIRE(mesh->NumberElementsLocal() == 16);
+
+    /* Ensure that we get a correct listing of all the boundary points. */
+    std::set<PetscInt> all_boundaries_true {
+        41, 44, 45, 48, 51, 52, 56, 61, 65, 70, 73, 74, 76, 78, 79, 80 };
+    REQUIRE(mesh->BoundaryPoints() == all_boundaries_true);
+
+
+
+  }
+
+  SECTION("Correctly initialize DM (3D hex).") {
+    PetscOptionsSetValue(NULL, "--mesh-file",  "small_hex_mesh_to_test_sources.e");
+    PetscOptionsSetValue(NULL, "--model-file", "small_hex_mesh_to_test_sources.e");
+    std::unique_ptr<Options> options(new Options);
+    options->setOptions();
+
+    /* Ensure mesh was read. */
+    auto mesh = Mesh::Factory(options);
+    mesh->read();
+    REQUIRE(mesh->DistributedMesh() != NULL);
+
+    /* Attach model and global dofs. */
+    std::unique_ptr<ExodusModel> model(new ExodusModel(options));
+    model->read();
+    mesh->setupGlobalDof(model, options);
+    REQUIRE(mesh->MeshSection() != NULL);
+
+    /* Ensure vertices are correct. */
+    HexVtx vtx;
+    vtx <<
+        0,     0,     0,
+        0,     0,     50000,
+        0,     50000, 50000,
+        0,     50000, 0,
+        50000, 0,     0,
+        50000, 50000, 0,
+        50000, 50000, 50000,
+        50000, 0,     50000;
+    REQUIRE(mesh->getElementCoordinateClosure(0).isApprox(vtx));
+
+    /* Ensure edges are consistent. */
+    std::vector<PetscInt> true_edges = { 35, 36, 37, 38, 39, 40 };
+    REQUIRE(mesh->EdgeNumbers(0) == true_edges);
+
+    /* Make sure our neighbours are properly known. */
+    REQUIRE_THROWS_AS(mesh->GetNeighbouringElement(35, 0), std::runtime_error);
+    REQUIRE_THROWS_AS(mesh->GetNeighbouringElement(37, 0), std::runtime_error);
+    REQUIRE_THROWS_AS(mesh->GetNeighbouringElement(40, 0), std::runtime_error);
+    REQUIRE(mesh->GetNeighbouringElement(36, 0) == 1);
+    REQUIRE(mesh->GetNeighbouringElement(38, 0) == 4);
+    REQUIRE(mesh->GetNeighbouringElement(39, 0) == 2);
+
+    /* TODO: Modify the mesh to include elements not on the edges. */
+    /* Ensure that we only return the physics of our neighbours. */
+    REQUIRE(mesh->CouplingFields((0)).size() == 3);
+    REQUIRE(mesh->CouplingFields((1)).size() == 3);
+    REQUIRE(mesh->CouplingFields((5)).size() == 3);
+
+    /* Ensure that we can get the proper physics from neighbour elements. */
+    for (auto &f: mesh->CouplingFields(0)) {
+      REQUIRE(std::get<1>(f).size() == 1);
+      REQUIRE(std::get<1>(f)[0] == "fluid");
+    }
+
+    /* Ensure that we get the proper physics for our element. */
+    REQUIRE(mesh->ElementFields(0)[0] == "fluid");
+
+    /* Ensure that, if we're on a boundary, we can detect that. */
+    REQUIRE(mesh->TotalCouplingFields(0)[0] == "boundary");
+    REQUIRE(mesh->TotalCouplingFields(1)[0] == "boundary");
+
+    /* TODO: See above TODO. */
+    /* Ensure that if we're in the middle of a homogeneous section, there's no coupling. */
+    /* REQUIRE(mesh->TotalCouplingFields(5).empty() == true); */
+
+    /* Ensure we know we're a hex. */
+    REQUIRE(mesh->baseElementType() == "hex");
+
+    /* Ensure we have the proper number of elements. */
+    REQUIRE(mesh->NumberElementsLocal() == 8);
+
+    /* Ensure that we get a correct listing of all the boundary points. */
+    std::set<PetscInt> all_boundaries_true {
+        35, 37, 40, 41, 42, 45, 46, 48, 50, 51, 52, 54, 55, 57, 59, 60,
+        61, 63, 64, 66, 67, 68, 69, 70 };
+    REQUIRE(mesh->BoundaryPoints() == all_boundaries_true);
+
+  }
+
+  SECTION("Mesh with at least some multi physics") {
+
+    PetscOptionsSetValue(NULL, "--mesh-file", "fluid_layer_over_elastic_cartesian_2D_50s.e");
+    PetscOptionsSetValue(NULL, "--model-file", "fluid_layer_over_elastic_cartesian_2D_50s.e");
+    std::unique_ptr<Options> options(new Options);
+    options->setOptions();
+
+    auto mesh = Mesh::Factory(options);
+    mesh->read();
+    std::unique_ptr<ExodusModel> model(new ExodusModel(options));
+    model->read();
+    mesh->setupGlobalDof(model, options);
+    std::set<std::string> all_fields_true = { "2delastic", "fluid" };
+    REQUIRE(mesh->AllFields() == all_fields_true);
+
+  }
+
+  SECTION("Mesh independent functionality.") {
+
+    PetscOptionsClear(NULL);
+    REQUIRE(Mesh::numFieldPerPhysics("fluid") == 1);
+    REQUIRE(Mesh::numFieldPerPhysics("2delastic") == 2);
+    REQUIRE(Mesh::numFieldPerPhysics("3delastic") == 3);
+    REQUIRE_THROWS_AS(Mesh::numFieldPerPhysics("4delastic"), std::runtime_error);
+
+  }
+
+}


### PR DESCRIPTION
Continuing my campaign to (almost) completely cover the code before we add any more functionality, here's some coverage for the mesh class. @rietmann pointed out that the new spectral ordering breaks tris and tets currently. I think this should be a relatively easy fix (worst case, we default to non-spectral ordering on these element types), but I'd hesitate to add it in currently. Reason being: I just heard from Matt, and there's now and even _newer_ way to set up the dofs, which should (hopefully) fix all our higehr order issues. So, I'll attempt to integrate this today.

As well, you'll notice the mesh class is now a lot leaner. True, a lot of bloat was removed. As well, some functionality was moved to areas where it was more appropriate. Perhaps the most notable example is the boundary flag strings, which I've moved to the Exodus model (no points opening and closing the exodus file another time just to get the side set labels). I hope to have this also merged in today, and (maybe) get the new symmetric permutations added.