### PR TITLE
Exit gracefully on unsupported order.

### DIFF
--- a/src/cxx/Element/HyperCube/Hexahedra.cpp
+++ b/src/cxx/Element/HyperCube/Hexahedra.cpp
@@ -20,7 +20,10 @@ template <typename ConcreteHex>
 Hexahedra<ConcreteHex>::Hexahedra(std::unique_ptr<Options> const &options) {
 
   /* Ensure we've set parameters correctly. */
-  assert(options->PolynomialOrder() > 0);
+  if (options->PolynomialOrder() <= 0 || options->PolynomialOrder() > mMaxOrder) {
+    throw std::runtime_error("Polynomial order " + std::to_string(options->PolynomialOrder()) +
+        " not supported for hex. Enter a value between 1 and " + std::to_string(mMaxOrder));
+  }
 
   // Basic properties.
   mPlyOrd = options->PolynomialOrder();
@@ -66,6 +69,7 @@ Hexahedra<ConcreteHex>::Hexahedra(std::unique_ptr<Options> const &options) {
 
 template <typename ConcreteHex>
 RealVec Hexahedra<ConcreteHex>::GllPointsForOrder(const PetscInt order) {
+  if (order > mMaxOrder) { throw std::runtime_error("Polynomial order not supported"); }
   RealVec gll_points(order + 1);
   if (order == 1) {
     gll_coordinates_order1_square(gll_points.data());
@@ -79,6 +83,7 @@ RealVec Hexahedra<ConcreteHex>::GllPointsForOrder(const PetscInt order) {
 
 template <typename ConcreteHex>
 RealVec Hexahedra<ConcreteHex>::GllIntegrationWeights(const PetscInt order) {
+  if (order > mMaxOrder) { throw std::runtime_error("Polynomial order not supported"); }
   RealVec integration_weights(order + 1);
   if (order == 1) {
     gll_weights_order1_square(integration_weights.data());
@@ -364,6 +369,7 @@ RealVec Hexahedra<ConcreteHex>::interpolateLagrangePolynomials(const PetscReal r
 
 {
 
+  if (order > mMaxOrder) { throw std::runtime_error("Polynomial order not supported"); }
   PetscInt n_points = (order + 1) * (order + 1) * (order + 1);
   RealVec gll_coeffs(n_points);
   if (order == 1) {
@@ -381,6 +387,7 @@ RealVec Hexahedra<ConcreteHex>::interpolateLagrangePolynomials(const PetscReal r
 template <typename ConcreteHex>
 RealMat  Hexahedra<ConcreteHex>::setupGradientOperator(const PetscInt order) {
 
+  if (order > mMaxOrder) { throw std::runtime_error("Polynomial order not supported"); }
   auto rn = GllPointsForOrder(order);
   PetscInt num_pts_r = rn.size();
   PetscInt num_pts_s = rn.size();

--- a/src/cxx/Element/HyperCube/TensorQuad.cpp
+++ b/src/cxx/Element/HyperCube/TensorQuad.cpp
@@ -16,7 +16,10 @@ template<typename ConcreteShape>
 TensorQuad<ConcreteShape>::TensorQuad(std::unique_ptr<Options> const &options) {
 
   /* Ensure we've set parameters correctly. */
-  assert(options->PolynomialOrder() > 0);
+  if (options->PolynomialOrder() <= 0 || options->PolynomialOrder() > mMaxOrder) {
+    throw std::runtime_error("Polynomial order " + std::to_string(options->PolynomialOrder()) +
+    " not supported for quad. Enter a value between 1 and " + std::to_string(mMaxOrder));
+  }
 
 
   mPlyOrd = options->PolynomialOrder();

--- a/src/cxx/Testing/test_TensorHex.cpp
+++ b/src/cxx/Testing/test_TensorHex.cpp
@@ -275,4 +275,17 @@ TEST_CASE("Test tensor hex", "[tensor_hex]") {
     REQUIRE(p1_test[i]->Receivers().size() == locations[i]);
   }
 
+  /* Require that proper errors are thrown. */
+  PetscOptionsSetValue(NULL, "--polynomial-order", "4");
+  options->setOptions();
+  REQUIRE_THROWS_AS(new Hexahedra<HexP1>(options), std::runtime_error);
+  REQUIRE_THROWS_AS(Hexahedra<HexP1>::GllPointsForOrder(
+      Hexahedra<HexP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(Hexahedra<HexP1>::GllIntegrationWeights(
+      Hexahedra<HexP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(Hexahedra<HexP1>::setupGradientOperator(
+      Hexahedra<HexP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(Hexahedra<HexP1>::interpolateLagrangePolynomials(
+      0, 0, 0, Hexahedra<HexP1>::MaxOrder()+1), std::runtime_error);
+
 }

--- a/src/cxx/Testing/test_TensorQuad.cpp
+++ b/src/cxx/Testing/test_TensorQuad.cpp
@@ -250,4 +250,20 @@ TEST_CASE("Test tensor quad", "[tensor_quad]") {
     REQUIRE(p1_test[0]->getEdgeNormal(edg_elm_zero[i]).isApprox(normals[i]));
   }
 
+  /* Require that proper errors are thrown. */
+  PetscOptionsSetValue(NULL, "--polynomial-order", "11");
+  options->setOptions();
+  REQUIRE_THROWS_AS(new TensorQuad<QuadP1>(options), std::runtime_error);
+  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::GllPointsForOrder(
+      TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::GllIntegrationWeightsForOrder(
+      TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::setupGradientOperator(
+      TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::interpolateLagrangePolynomials(
+      0, 0, TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
+  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::ClosureMappingForOrder(
+      TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
+
+
 }


### PR DESCRIPTION
Salvus should now exit gracefully with a runtime exception if an unsupported polynomial order is detected.