### PR TITLE
Afanasiev/get side sets from model

### DIFF
--- a/include/Model/ExodusModel.h
+++ b/include/Model/ExodusModel.h
@@ -132,5 +132,13 @@ class ExodusModel {
    */
   std::string getElementType(const Eigen::VectorXd &elem_center);
 
+  /**
+   * Returns the a string specifying the side set name (x0, x1, ...).
+   * @param side_set_num Exodus side set identifier [0, nSideSet].
+   * @return Side set name.
+   */
+  std::string SideSetName(const PetscInt side_set_num);
+
+
 };
 

--- a/src/cxx/Model/ExodusModel.cpp
+++ b/src/cxx/Model/ExodusModel.cpp
@@ -407,4 +407,15 @@ void ExodusModel::readSideSets() {
   for (int i = 0; i < mNumberSideSets; i++) { free (nm[i]); }
 
 }
+std::string ExodusModel::SideSetName(const PetscInt side_set_num) {
+
+  if (side_set_num >= mNumberSideSets) {
+    throw std::runtime_error(
+        "Side set " + std::to_string(side_set_num) + " is not in Exodus file. "
+            "Defined side sets range from 0 to " + std::to_string(mNumberSideSets));
+  }
+
+  return mSideSetNames[side_set_num];
+
+}
 

--- a/src/cxx/Testing/test_Model.cpp
+++ b/src/cxx/Testing/test_Model.cpp
@@ -65,6 +65,7 @@ TEST_CASE("Unit test model", "[model]") {
       for (auto i: {0, 1, 2, 3}) {
         REQUIRE(model->SideSetName(i) == true_side_sets[i]);
       }
+      REQUIRE_THROWS_AS(model->SideSetName(4), std::runtime_error);
 
     }
 
@@ -119,6 +120,7 @@ TEST_CASE("Unit test model", "[model]") {
       for (auto i: {0, 1, 2, 3, 4, 5}) {
         REQUIRE(model->SideSetName(i) == true_side_sets[i]);
       }
+      REQUIRE_THROWS_AS(model->SideSetName(6), std::runtime_error);
 
     }
 

--- a/src/cxx/Testing/test_Model.cpp
+++ b/src/cxx/Testing/test_Model.cpp
@@ -59,6 +59,15 @@ TEST_CASE("Unit test model", "[model]") {
                         std::runtime_error);
     }
 
+    SECTION("Check side sets") {
+
+      std::vector<std::string> true_side_sets { "x0", "x1", "y0", "y1" };
+      for (auto i: {0, 1, 2, 3}) {
+        REQUIRE(model->SideSetName(i) == true_side_sets[i]);
+      }
+
+    }
+
   }
 
   SECTION("Test hexes") {
@@ -102,6 +111,15 @@ TEST_CASE("Unit test model", "[model]") {
       /* Only elemental variables defined for this mesh. */
       REQUIRE_THROWS_AS(model->getNodalParameterAtNode({0.0, 0.0, 0.0}, "fail"),
                         std::runtime_error);
+    }
+
+    SECTION("Check side sets") {
+
+      std::vector<std::string> true_side_sets{"x0", "x1", "y0", "y1", "z0", "z1"};
+      for (auto i: {0, 1, 2, 3, 4, 5}) {
+        REQUIRE(model->SideSetName(i) == true_side_sets[i]);
+      }
+
     }
 
   }


### PR DESCRIPTION
Added a new function SideSetNames, which takes a side set number [0,
nSideSets], and returns the name given to it from the Exodus file.
Useful for runtime decisions of absorbing boundaries, and whatnot.