### PR TITLE
Added unit tests for using nodal parameters.

### DIFF
--- a/include/Model/ExodusModel.h
+++ b/include/Model/ExodusModel.h
@@ -9,6 +9,7 @@
 #include <mpi.h>
 #include <petsc.h>
 #include <Eigen/Dense>
+#include <Utilities/Types.h>
 
 extern "C" {
 #include "Utilities/kdtree.h"
@@ -111,7 +112,7 @@ class ExodusModel {
    * @param [in] parameter_name Name of material parameter.
    * @return The value of the closest material parameter defined at a point.
    */
-  PetscReal getNodalParameterAtNode(const std::vector<PetscReal> point,
+  PetscReal getNodalParameterAtNode(const Eigen::Ref<const RealVec>& point,
                                     const std::string parameter_name);
 
   /**
@@ -122,7 +123,7 @@ class ExodusModel {
    * @param [in] vertex_num The vertex for which the parameter is desired.
    * @return The value of the material parameter at the specified vertex.
    */
-  PetscScalar getElementalMaterialParameterAtVertex(const Eigen::VectorXd &elem_center,
+  PetscScalar getElementalMaterialParameterAtVertex(const Eigen::Ref<const RealVec>& elem_center,
                                                     std::string parameter_name,
                                                     const PetscInt vertex_num) const;
 

--- a/src/cxx/Model/ExodusModel.cpp
+++ b/src/cxx/Model/ExodusModel.cpp
@@ -262,13 +262,20 @@ void ExodusModel::readElementalVariables() {
 
 }
 
-PetscReal ExodusModel::getNodalParameterAtNode(const std::vector<PetscReal> point,
+PetscReal ExodusModel::getNodalParameterAtNode(const Eigen::Ref<const RealVec>& point,
                                                const std::string parameter_name) {
 
   if (!mNodalVariables.size()) {
     throw std::runtime_error(
         "You've tried to query a nodal parameter, but none are defined. "
             "Perhaps you meant to try an elemental parameter?" );
+  }
+
+  if (std::find(mNodalVariableNames.begin(), mNodalVariableNames.end(), parameter_name) ==
+      mNodalVariableNames.end()) {
+    throw std::runtime_error(
+        "Parameter " + parameter_name + " does not exist as a nodal parameter in "
+            "file " + mExodusFileName);
   }
 
   // Get spatial index.
@@ -296,7 +303,7 @@ void ExodusModel::readConnectivity() {
 
 }
 
-PetscScalar ExodusModel::getElementalMaterialParameterAtVertex(const Eigen::VectorXd &elem_center,
+PetscScalar ExodusModel::getElementalMaterialParameterAtVertex(const Eigen::Ref<const RealVec> &elem_center,
                                                                std::string parameter_name,
                                                                const PetscInt vertex_num) const {
   assert(elem_center.size() == mNumberDimension);
@@ -328,8 +335,8 @@ PetscScalar ExodusModel::getElementalMaterialParameterAtVertex(const Eigen::Vect
         parameter_name = "VP";
         throw salvus_warning("Anisotropic VPV requested, but can only find isotropic VP. Using VP!");
       } else {
-        throw std::runtime_error("Requested parameter " + parameter_name + " which is not in the "
-            "model file " + mExodusFileName);
+        throw std::runtime_error("Requested parameter " + parameter_name + " which is not stored as an "
+            "elemental variable in file " + mExodusFileName);
       }
     }
   } catch (salvus_warning &e) {


### PR DESCRIPTION
The model class correctly returns the closest nodal parameter value for
a given query, or throws an exception if one does not exist. From the
elment / physics side, we are still looking for elemental parameters. We
need to discuss: which should be the default case?