### PR TITLE
Added closure passing to get/set elements.

### DIFF
--- a/include/Element/HyperCube/Hexahedra.h
+++ b/include/Element/HyperCube/Hexahedra.h
@@ -271,7 +271,7 @@ private:
   inline PetscInt NumDofFac() const { return mNumDofFac; }
   inline PetscInt NumDofEdg() const { return mNumDofEdg; }
   inline PetscInt NumDofVtx() const { return mNumDofVtx; }
-  inline IntVec ClsMap() const { return IntVec(mNumIntPnt); }
+  inline IntVec ClsMap() const { return mClsMap; }
   inline RealMat VtxCrd() const { return mVtxCrd; }
   inline static PetscInt MaxOrder() { return mMaxOrder; }
   inline void SetVtxPar(const Eigen::Ref<const RealVec> &v, const std::string &par) { mPar[par] = v; }

--- a/include/Element/HyperCube/TensorQuad.h
+++ b/include/Element/HyperCube/TensorQuad.h
@@ -153,8 +153,6 @@ private:
   static RealVec interpolateLagrangePolynomials(const PetscReal r, const PetscReal s,
                                                 const PetscInt order);
 
-  static IntVec  ClosureMappingForOrder(const PetscInt order);
-
   /**
    * Compute the gradient of a field at all GLL points.
    * @param [in] field Field to take the gradient of.

--- a/src/cxx/Element/HyperCube/Hexahedra.cpp
+++ b/src/cxx/Element/HyperCube/Hexahedra.cpp
@@ -52,6 +52,9 @@ Hexahedra<ConcreteHex>::Hexahedra(std::unique_ptr<Options> const &options) {
   mGrd = setupGradientOperator(mPlyOrd);
   mGrdT = mGrd.transpose();
 
+  /* Identity closure for tensor basis. */
+  mClsMap = IntVec::LinSpaced(mNumIntPnt, 0, mNumIntPnt - 1);
+
   mGrdWgt.resize(mNumIntPtsR,mNumIntPtsR);
   for(PetscInt i=0;i<mNumIntPtsR;i++) {
     for(PetscInt j=0;j<mNumIntPtsR;j++) {

--- a/src/cxx/Element/HyperCube/TensorQuad.cpp
+++ b/src/cxx/Element/HyperCube/TensorQuad.cpp
@@ -29,7 +29,6 @@ TensorQuad<ConcreteShape>::TensorQuad(std::unique_ptr<Options> const &options) {
   mNumDofVol = 0;
 
   mGrd = TensorQuad<ConcreteShape>::setupGradientOperator(mPlyOrd);
-  mClsMap = TensorQuad<ConcreteShape>::ClosureMappingForOrder(mPlyOrd);
   mIntCrdR = TensorQuad<ConcreteShape>::GllPointsForOrder(mPlyOrd);
   mIntCrdS = TensorQuad<ConcreteShape>::GllPointsForOrder(mPlyOrd);
   mIntWgtR = TensorQuad<ConcreteShape>::GllIntegrationWeightsForOrder(mPlyOrd);
@@ -38,6 +37,8 @@ TensorQuad<ConcreteShape>::TensorQuad(std::unique_ptr<Options> const &options) {
   mNumIntPtsS = mIntCrdS.size();
   mNumIntPtsR = mIntWgtR.size();
   mNumIntPnt = mNumIntPtsS * mNumIntPtsR;
+  /* Identity closure for tensor basis. */
+  mClsMap = IntVec::LinSpaced(mNumIntPnt, 0, mNumIntPnt - 1);
 
   mDetJac.setZero(mNumIntPnt);
   mParWork.setZero(mNumIntPnt);

--- a/src/cxx/Element/HyperCube/TensorQuad.cpp
+++ b/src/cxx/Element/HyperCube/TensorQuad.cpp
@@ -174,34 +174,6 @@ RealVec TensorQuad<ConcreteShape>::interpolateLagrangePolynomials(const PetscRea
 }
 
 template<typename ConcreteShape>
-IntVec TensorQuad<ConcreteShape>::ClosureMappingForOrder(const PetscInt order) {
-  if (order > mMaxOrder) { throw std::runtime_error("Polynomial order not supported"); }
-  IntVec closure_mapping((order + 1) * (order + 1));
-  if (order == 1) {
-    closure_mapping_order1_square(closure_mapping.data());
-  } else if (order == 2) {
-    closure_mapping_order2_square(closure_mapping.data());
-  } else if (order == 3) {
-    closure_mapping_order3_square(closure_mapping.data());
-  } else if (order == 4) {
-    closure_mapping_order4_square(closure_mapping.data());
-  } else if (order == 5) {
-    closure_mapping_order5_square(closure_mapping.data());
-  } else if (order == 6) {
-    closure_mapping_order6_square(closure_mapping.data());
-  } else if (order == 7) {
-    closure_mapping_order7_square(closure_mapping.data());
-  } else if (order == 8) {
-    closure_mapping_order8_square(closure_mapping.data());
-  } else if (order == 9) {
-    closure_mapping_order9_square(closure_mapping.data());
-  } else if (order == 10) {
-    closure_mapping_order10_square(closure_mapping.data());
-  }
-  return closure_mapping;
-}
-
-template<typename ConcreteShape>
 RealMat TensorQuad<ConcreteShape>::computeGradient(const Ref<const RealVec> &field) {
 
   RealVec2 refGrad;

--- a/src/cxx/Testing/test_TensorQuad.cpp
+++ b/src/cxx/Testing/test_TensorQuad.cpp
@@ -264,8 +264,5 @@ TEST_CASE("Test tensor quad", "[tensor_quad]") {
       TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
   REQUIRE_THROWS_AS(TensorQuad<QuadP1>::interpolateLagrangePolynomials(
       0, 0, TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
-  REQUIRE_THROWS_AS(TensorQuad<QuadP1>::ClosureMappingForOrder(
-      TensorQuad<QuadP1>::MaxOrder()+1), std::runtime_error);
-
 
 }


### PR DESCRIPTION
Simplex elements don't have a natural ordering, so it is still useful to
pass element-specific closure vectors to the get/set routines. This
merge adds that functionality.

- Natural spectral ordering for hex / quad, so the closure vector is just a LinSpace.