### PR TITLE
Choose boundary types at runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ add_executable(salvus_test
         src/cxx/Testing/test_receiver.cpp
         src/cxx/Testing/test_Element.cpp
         src/cxx/Testing/test_Mesh.cpp
-        src/cxx/Testing/test_Model.cpp)
+        src/cxx/Testing/test_Model.cpp
+        src/cxx/Testing/test_Options.cpp)
 
 # run `make` (or `make -j5`) to build `salvus` executable
 target_link_libraries(salvus salvusCommon ${MPI_LIBRARIES} petsc exodus netcdf hdf5)

--- a/include/Mesh/Mesh.h
+++ b/include/Mesh/Mesh.h
@@ -23,7 +23,7 @@ using std::unique_ptr;
 
 class Mesh {
 
-  std::set<PetscInt> mBndPts;
+  std::vector<std::tuple<PetscInt,PetscInt>> mBndPts;
 
   /** Keeps track of all the fields defined in the mesh. **/
   std::set<std::string> mMeshFields;
@@ -189,7 +189,7 @@ class Mesh {
 
   std::map<PetscInt, std::string> &BoundaryIds() { return mBoundaryIds; }
 
-  inline std::set<PetscInt> BoundaryPoints() { return mBndPts; }
+  inline std::vector<std::tuple<PetscInt,PetscInt>> BoundaryPoints() { return mBndPts; }
 
   inline int NumberSideSets() { return mNumberSideSets; }
   inline int NumberDimensions() { return mNumDim; }

--- a/include/Utilities/Options.h
+++ b/include/Utilities/Options.h
@@ -44,6 +44,9 @@ class Options {
   std::vector<std::string> mRecNames;
   std::vector<std::string> mMovieFields;
 
+  // Boundaries.
+  std::vector<std::string> mHomogeneousDirichletBoundaries;
+
  public:
 
   void setOptions();
@@ -77,6 +80,8 @@ class Options {
 
   std::vector<std::string> RecNames() const { return mRecNames; }
   std::vector<std::string> MovieFields() const { return mMovieFields; }
+
+  std::vector<std::string> HomogeneousDirichlet() const { return mHomogeneousDirichletBoundaries; }
 
   /* Setters (mainly for testing). */
   void SetDimension(const PetscInt dim) { mNumDim = dim; }

--- a/src/cxx/Element/Element.cpp
+++ b/src/cxx/Element/Element.cpp
@@ -32,23 +32,23 @@ enum phys_code {
   /* Pure fluid. */
   eFluid,
   /* Pure fluid on mesh boundary. */
-  eFluidBoundary,
+  eFluidBoundaryHomoDirichlet,
   /* Pure 2d elastic. */
   eElastic2D,
   /* 2D elastic boundary. */
-  eElastic2DBoundary,
+  eElastic2DBoundaryHomoDirichlet,
   /* Pure 3d elastic. */
   eElastic3D,
   /* 3D elastic boundary. */
-  eElastic3DBoundary,
+  eElastic3DBoundaryHomoDirichlet,
   /* 2D fluid couple to base solid. */
   eFluidToSolid2D,
   /* 2D solid couple to base fluid. */
   eSolidToFluid2D,
   /* 2D solid couple to base fluid on boundary. */
-  eSolidToFluidBoundary2D,
+  eSolidToFluidBoundary2DHomoDirichlet,
   /* 2D fluid couple to base solid on boundary. */
-  eFluidToSolidBoundary2D,
+  eFluidToSolidBoundary2DHomoDirichlet,
   /* If nothing appropriate was found. */
   eError
 };
@@ -66,13 +66,13 @@ phys_code ptype(const std::vector<std::string> &ptype, const std::vector<std::st
     } else if (cset.size() == 1) {
       if (cset.find("2delastic") != cset.end()) {
         return eSolidToFluid2D;
-      } else if (cset.find("boundary") != cset.end()) {
-        return eFluidBoundary;
+      } else if (cset.find("boundary_homo_dirichlet") != cset.end()) {
+        return eFluidBoundaryHomoDirichlet;
       }
     } else if (cset.size() == 2) {
       if (cset.find("2delastic") != cset.end() &&
-          cset.find("boundary")  != cset.end()) {
-        return eSolidToFluidBoundary2D;
+          cset.find("boundary_homo_dirichlet")  != cset.end()) {
+        return eSolidToFluidBoundary2DHomoDirichlet;
       }
     } else {
       return eError;
@@ -85,13 +85,13 @@ phys_code ptype(const std::vector<std::string> &ptype, const std::vector<std::st
     else if (cset.size() == 1) {
       if (cset.find("fluid") != cset.end()) {
         return eFluidToSolid2D;
-      } else if (cset.find("boundary") != cset.end()) {
-        return eElastic2DBoundary;
+      } else if (cset.find("boundary_homo_dirichlet") != cset.end()) {
+        return eElastic2DBoundaryHomoDirichlet;
       }
     } else if (cset.size() == 2) {
       if ((cset.find("fluid") != cset.end()) &&
-          (cset.find("boundary") != cset.end())) {
-        return eFluidToSolidBoundary2D;
+          (cset.find("boundary_homo_dirichlet") != cset.end())) {
+        return eFluidToSolidBoundary2DHomoDirichlet;
       }
     } else {
       return eError;
@@ -101,8 +101,8 @@ phys_code ptype(const std::vector<std::string> &ptype, const std::vector<std::st
     if (cset.empty()) {
       return eElastic3D;
     } else if (cset.size() == 1) {
-      if (cset.find("boundary") != cset.end()) {
-        return eElastic3DBoundary;
+      if (cset.find("boundary_homo_dirichlet") != cset.end()) {
+        return eElastic3DBoundaryHomoDirichlet;
       }
     } else {
       return eError;
@@ -139,7 +139,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                       TensorQuad<
                           QuadP1>>>(options));
 
-        case eFluidBoundary:
+        case eFluidBoundaryHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<
@@ -147,7 +147,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                           TensorQuad<
                               QuadP1>>>>(options));
 
-        case eElastic2DBoundary:
+        case eElastic2DBoundaryHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<
@@ -171,7 +171,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                           TensorQuad<
                               QuadP1>>>>(options));
 
-        case eSolidToFluidBoundary2D:
+        case eSolidToFluidBoundary2DHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<
@@ -180,7 +180,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                               TensorQuad<
                                   QuadP1>>>>>(options));
 
-        case eFluidToSolidBoundary2D:
+        case eFluidToSolidBoundary2DHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<
@@ -214,7 +214,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                       Hexahedra<
                           HexP1>>>(options));
 
-        case eFluidBoundary:
+        case eFluidBoundaryHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<
@@ -222,7 +222,7 @@ std::unique_ptr<Element> Element::Factory(const std::string &shape,
                           Hexahedra<
                               HexP1>>>>(options));
 
-        case eElastic3DBoundary:
+        case eElastic3DBoundaryHomoDirichlet:
           return std::unique_ptr<Element> (
               new ElementAdapter<
                   HomogeneousDirichlet<

--- a/src/cxx/Physics/Boundary/HomogeneousDirichlet.cpp
+++ b/src/cxx/Physics/Boundary/HomogeneousDirichlet.cpp
@@ -15,8 +15,10 @@ void HomogeneousDirichlet<Base>::setBoundaryConditions(std::unique_ptr<Mesh> con
   auto bnds = mesh->BoundaryPoints();
   PetscInt num_pts; DMPlexGetConeSize(mesh->DistributedMesh(), Base::ElmNum(), &num_pts);
   const PetscInt *pts = NULL; DMPlexGetCone(mesh->DistributedMesh(), Base::ElmNum(), &pts);
-  for (PetscInt i = 0; i < num_pts; i++) {
-    if (bnds.find(pts[i]) != bnds.end()) { mBndEdg.push_back(i); }
+  for (auto &pnt: bnds) {
+    for (PetscInt i = 0; i < num_pts; i++) {
+      if (std::get<1>(pnt) == pts[i]) { mBndEdg.push_back(i); }
+    }
   }
 
   Base::setBoundaryConditions(mesh);

--- a/src/cxx/Testing/test_Element.cpp
+++ b/src/cxx/Testing/test_Element.cpp
@@ -20,28 +20,28 @@ TEST_CASE("Test to make sure proper elements are returned.", "[element]") {
 
   REQUIRE(Element::Factory("quad", {"fluid"}, {}, options)->Name() ==
       "Scalar_TensorQuad_QuadP1");
-  REQUIRE(Element::Factory("quad", {"fluid"}, {"boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("quad", {"fluid"}, {"boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_Scalar_TensorQuad_QuadP1");
   REQUIRE(Element::Factory("quad", {"fluid"}, {"2delastic"}, options)->Name() ==
       "SolidToFluid2D_Scalar_TensorQuad_QuadP1");
-  REQUIRE(Element::Factory("quad", {"fluid"}, {"2delastic", "boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("quad", {"fluid"}, {"2delastic", "boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_SolidToFluid2D_Scalar_TensorQuad_QuadP1");
   REQUIRE(Element::Factory("quad", {"2delastic"}, {}, options)->Name() ==
       "Elastic2D_TensorQuad_QuadP1");
   REQUIRE(Element::Factory("quad", {"2delastic"}, {"fluid"}, options)->Name() ==
       "FluidToSolid2D_Elastic2D_TensorQuad_QuadP1");
-  REQUIRE(Element::Factory("quad", {"2delastic"}, {"boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("quad", {"2delastic"}, {"boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_Elastic2D_TensorQuad_QuadP1");
-  REQUIRE(Element::Factory("quad", {"2delastic"}, {"fluid", "boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("quad", {"2delastic"}, {"fluid", "boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_FluidToSolid2D_Elastic2D_TensorQuad_QuadP1");
 
   REQUIRE(Element::Factory("hex", {"fluid"}, {}, options)->Name() ==
       "Scalar_TensorHex_HexP1");
-  REQUIRE(Element::Factory("hex", {"fluid"}, {"boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("hex", {"fluid"}, {"boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_Scalar_TensorHex_HexP1");
   REQUIRE(Element::Factory("hex", {"3delastic"}, {}, options)->Name() ==
       "Elastic3D_TensorHex_HexP1");
-  REQUIRE(Element::Factory("hex", {"3delastic"}, {"boundary"}, options)->Name() ==
+  REQUIRE(Element::Factory("hex", {"3delastic"}, {"boundary_homo_dirichlet"}, options)->Name() ==
       "HomogeneousDirichlet_Elastic3D_TensorHex_HexP1");
 
   /* Make sure dumb values are not allowed. */
@@ -55,9 +55,9 @@ TEST_CASE("Test to make sure proper elements are returned.", "[element]") {
   REQUIRE_THROWS_AS(Element::Factory("quad", {"2deastic"}, {}, options)->Name(),
                     std::runtime_error);
 
-  REQUIRE_THROWS_AS(Element::Factory("quad", {"2delastic", "fluid", "boundary"}, {}, options)->Name(),
+  REQUIRE_THROWS_AS(Element::Factory("quad", {"2delastic", "fluid", "boundary_homo_dirichlet"}, {}, options)->Name(),
                     std::runtime_error);
-  REQUIRE_THROWS_AS(Element::Factory("hex", {"3delastic", "fluid", "boundary"}, {}, options)->Name(),
+  REQUIRE_THROWS_AS(Element::Factory("hex", {"3delastic", "fluid", "boundary_homo_dirichlet"}, {}, options)->Name(),
                     std::runtime_error);
 
   REQUIRE_THROWS_AS(Element::Factory("quad", {"fluid"}, {"cat", "dog", "korbinian"}, options)->Name(),

--- a/src/cxx/Testing/test_Hex_Scalar_3D.cpp
+++ b/src/cxx/Testing/test_Hex_Scalar_3D.cpp
@@ -90,7 +90,9 @@ TEST_CASE("Test analytic eigenfunction solution for scalar "
       "--mesh-file", e_file.c_str(),
       "--model-file", e_file.c_str(),
       "--time-step", "1e-2",
-      "--polynomial-order", "2", NULL};
+      "--polynomial-order", "2",
+      "--homogeneous-dirichlet", "x0,x1,y0,y1,z0,z1",
+      NULL};
   char **argv = const_cast<char **> (arg);
   int argc = sizeof(arg) / sizeof(const char *) - 1;
   PetscOptionsInsert(NULL, &argc, &argv, NULL);

--- a/src/cxx/Testing/test_Options.cpp
+++ b/src/cxx/Testing/test_Options.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <salvus.h>
+#include "catch.h"
+
+
+TEST_CASE("Unit test options", "[options]") {
+
+  SECTION("Homogeneous Dirichlet") {
+    PetscOptionsClear(NULL);
+    const char *arg[] = {
+        "salvus_test",
+        "--testing", "true",
+        "--homogeneous-dirichlet", "x0,x1",
+        NULL};
+
+    /* Fake setting via command line. */
+    char **argv = const_cast<char **> (arg);
+    int argc = sizeof(arg) / sizeof(const char *) - 1;
+    PetscOptionsInsert(NULL, &argc, &argv, NULL);
+
+    std::unique_ptr<Options> options(new Options);
+    options->setOptions();
+    std::vector<std::string> bnds {"x0", "x1"};
+    REQUIRE(options->HomogeneousDirichlet() == bnds);
+
+  }
+
+}

--- a/src/cxx/Testing/test_Quad_Scalar_2D.cpp
+++ b/src/cxx/Testing/test_Quad_Scalar_2D.cpp
@@ -157,7 +157,9 @@ TEST_CASE("Test analytic eigenfunction solution for scalar "
       "--mesh-file", e_file.c_str(),
       "--model-file", e_file.c_str(),
       "--time-step", "1e-2",
-      "--polynomial-order", "4", NULL};
+      "--polynomial-order", "4",
+      "--homogeneous-dirichlet", "x0,x1,y0,y1",
+      NULL};
   char **argv = const_cast<char **> (arg);
   int argc = sizeof(arg) / sizeof(const char *) - 1;
   PetscOptionsInsert(NULL, &argc, &argv, NULL);
@@ -198,6 +200,7 @@ TEST_CASE("Test analytic eigenfunction solution for scalar "
 
     l3->setupEigenfunctionTest(mesh, options, problem, fields);
 
+    /* TODO: How does this work?? Static cast magic? Where is the HomogeneousDirichlet? */
     /* Now we have a class with testing, which is still really an element :) */
     test_elements.emplace_back(static_cast<test_insert*>(l3));
 

--- a/src/cxx/Utilities/Options.cpp
+++ b/src/cxx/Utilities/Options.cpp
@@ -64,6 +64,14 @@ void Options::setOptions() {
     if (! testing) throw std::runtime_error(epre + "--dimension" + epst);
   }
 
+  /********************************************************************************
+                                     Boundaries.
+  ********************************************************************************/
+  char *bounds[PETSC_MAX_PATH_LEN]; PetscInt num_bnd = PETSC_MAX_PATH_LEN;
+  PetscOptionsGetStringArray(NULL, NULL, "--homogeneous-dirichlet", bounds, &num_bnd, &parameter_set);
+  if (parameter_set) {
+    for (PetscInt i = 0; i < num_bnd; i++) { mHomogeneousDirichletBoundaries.push_back(bounds[i]); }
+  }
 
   /********************************************************************************
                                        Movies.


### PR DESCRIPTION
Added a new option to specify boundaries at runtime. Currently,
homogeneous Dirichlet and free surfaces are supported. To use, the user
would pass --homogeneous-dirichlet x0,x1,y0 to Salvus, which would make
those three interfaces Dirichlet boundaries. If a boundary is not
specified, it is by default a free surface. Notice that the
eigenfunction tests have been modified as well: we now mock the passing
of --homogeneous-dirichlet. Indeed, those tests fail if this is not
passed.

The specific strings defining the boundaries to use are those which are defined in the exodus file (i.e. the side set names). x0,x1,y0,y1, etc are the defaults from the mesher.