### PR TITLE
Configure Travis CI to use specific branch of salvus_data (if it exists)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,13 @@ install:
   # Install salvus_data as well.
   - cd; cd build
   - git clone https://github.com/SalvusHub/salvus_data.git
-
+  # check whether branch exists on salvus_data
+  - echo $TRAVIS_BRANCH
+  - cd salvus_data
+  - if [[ $(git rev-parse --verify $TRAVIS_BRANCH) ]]; then git checkout $TRAVIS_BRANCH; fi 
+  
 script:
-  - cd salvus_data/new_unit_tests
+  - cd ./new_unit_tests
   - sh ./run_travis.sh
   - cd /home/travis/build/SalvusHub/salvus/build
 


### PR DESCRIPTION
If a branch with the same name exists in salvus_data it will be checked out during testing.
Otherwise, the master branch of salvus_data is used.